### PR TITLE
Restructure SDK to multi-file distribution with subpath imports

### DIFF
--- a/objectiveai-js/package.json
+++ b/objectiveai-js/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "shx rm -f .schema-cache.json && shx rm -rf dist && node ./scripts/install-wasm.cjs && npx tsx scripts/precompute-schemas.ts && tsup && shx rm -f dist/*.d.mts && shx rm -f dist/*.d.cts && shx rm -f .schema-cache.json",
+    "build": "shx rm -f .schema-cache.json && shx rm -rf dist && node ./scripts/install-wasm.cjs && npx tsx scripts/precompute-schemas.ts && tsup && shx rm -f .schema-cache.json",
     "test": "node test/test-cjs.cjs && node test/test-esm.mjs && vitest run",
     "start": "node dist/index.js"
   },
@@ -57,6 +57,106 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./auth": {
+      "types": "./dist/auth/index.d.ts",
+      "import": "./dist/auth/index.js",
+      "require": "./dist/auth/index.cjs"
+    },
+    "./chat": {
+      "types": "./dist/chat/index.d.ts",
+      "import": "./dist/chat/index.js",
+      "require": "./dist/chat/index.cjs"
+    },
+    "./chat/completions": {
+      "types": "./dist/chat/completions/index.d.ts",
+      "import": "./dist/chat/completions/index.js",
+      "require": "./dist/chat/completions/index.cjs"
+    },
+    "./ensemble": {
+      "types": "./dist/ensemble/index.d.ts",
+      "import": "./dist/ensemble/index.js",
+      "require": "./dist/ensemble/index.cjs"
+    },
+    "./ensemble_llm": {
+      "types": "./dist/ensemble_llm/index.d.ts",
+      "import": "./dist/ensemble_llm/index.js",
+      "require": "./dist/ensemble_llm/index.cjs"
+    },
+    "./functions": {
+      "types": "./dist/functions/index.d.ts",
+      "import": "./dist/functions/index.js",
+      "require": "./dist/functions/index.cjs"
+    },
+    "./functions/expression": {
+      "types": "./dist/functions/expression/index.d.ts",
+      "import": "./dist/functions/expression/index.js",
+      "require": "./dist/functions/expression/index.cjs"
+    },
+    "./functions/executions": {
+      "types": "./dist/functions/executions/index.d.ts",
+      "import": "./dist/functions/executions/index.js",
+      "require": "./dist/functions/executions/index.cjs"
+    },
+    "./functions/profiles": {
+      "types": "./dist/functions/profiles/index.d.ts",
+      "import": "./dist/functions/profiles/index.js",
+      "require": "./dist/functions/profiles/index.cjs"
+    },
+    "./functions/quality": {
+      "types": "./dist/functions/quality/index.d.ts",
+      "import": "./dist/functions/quality/index.js",
+      "require": "./dist/functions/quality/index.cjs"
+    },
+    "./vector": {
+      "types": "./dist/vector/index.d.ts",
+      "import": "./dist/vector/index.js",
+      "require": "./dist/vector/index.cjs"
+    },
+    "./vector/completions": {
+      "types": "./dist/vector/completions/index.d.ts",
+      "import": "./dist/vector/completions/index.js",
+      "require": "./dist/vector/completions/index.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "auth": [
+        "dist/auth/index.d.ts"
+      ],
+      "chat": [
+        "dist/chat/index.d.ts"
+      ],
+      "chat/completions": [
+        "dist/chat/completions/index.d.ts"
+      ],
+      "ensemble": [
+        "dist/ensemble/index.d.ts"
+      ],
+      "ensemble_llm": [
+        "dist/ensemble_llm/index.d.ts"
+      ],
+      "functions": [
+        "dist/functions/index.d.ts"
+      ],
+      "functions/expression": [
+        "dist/functions/expression/index.d.ts"
+      ],
+      "functions/executions": [
+        "dist/functions/executions/index.d.ts"
+      ],
+      "functions/profiles": [
+        "dist/functions/profiles/index.d.ts"
+      ],
+      "functions/quality": [
+        "dist/functions/quality/index.d.ts"
+      ],
+      "vector": [
+        "dist/vector/index.d.ts"
+      ],
+      "vector/completions": [
+        "dist/vector/completions/index.d.ts"
+      ]
     }
   },
   "files": [

--- a/objectiveai-js/test/test-cjs.cjs
+++ b/objectiveai-js/test/test-cjs.cjs
@@ -1,4 +1,4 @@
-// Test CommonJS import
+// Test CommonJS import — top-level namespace
 const ObjectiveAI = require("../dist/index.cjs");
 
 console.log("Testing CommonJS...");
@@ -19,5 +19,50 @@ ObjectiveAI.EnsembleLlm.validate({
   model: "openai/gpt-5-nano",
   output_mode: "instruction",
 });
+
+console.log("  ✓ Top-level namespace import works");
+
+// Test CommonJS subpath imports
+const Functions = require("../dist/functions/index.cjs");
+if (typeof Functions !== "object" || Functions === null || Object.keys(Functions).length === 0) {
+  console.log("  ✗ Functions subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Functions subpath import works");
+
+const Expression = require("../dist/functions/expression/index.cjs");
+if (typeof Expression !== "object" || Expression === null || Object.keys(Expression).length === 0) {
+  console.log("  ✗ Functions/Expression subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Functions/Expression subpath import works");
+
+const EnsembleLlm = require("../dist/ensemble_llm/index.cjs");
+if (typeof EnsembleLlm !== "object" || EnsembleLlm === null || Object.keys(EnsembleLlm).length === 0) {
+  console.log("  ✗ EnsembleLlm subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ EnsembleLlm subpath import works");
+
+const Chat = require("../dist/chat/index.cjs");
+if (typeof Chat !== "object" || Chat === null || Object.keys(Chat).length === 0) {
+  console.log("  ✗ Chat subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Chat subpath import works");
+
+const Vector = require("../dist/vector/index.cjs");
+if (typeof Vector !== "object" || Vector === null || Object.keys(Vector).length === 0) {
+  console.log("  ✗ Vector subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Vector subpath import works");
+
+const Ensemble = require("../dist/ensemble/index.cjs");
+if (typeof Ensemble !== "object" || Ensemble === null || Object.keys(Ensemble).length === 0) {
+  console.log("  ✗ Ensemble subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Ensemble subpath import works");
 
 console.log("CommonJS: PASSED");

--- a/objectiveai-js/test/test-esm.mjs
+++ b/objectiveai-js/test/test-esm.mjs
@@ -1,4 +1,4 @@
-// Test ESM import
+// Test ESM import — top-level namespace
 import * as ObjectiveAI from "../dist/index.js";
 
 console.log("Testing ESM...");
@@ -19,5 +19,50 @@ ObjectiveAI.EnsembleLlm.validate({
   model: "openai/gpt-5-nano",
   output_mode: "instruction",
 });
+
+console.log("  ✓ Top-level namespace import works");
+
+// Test ESM subpath imports
+import * as Functions from "../dist/functions/index.js";
+if (typeof Functions !== "object" || Functions === null || Object.keys(Functions).length === 0) {
+  console.log("  ✗ Functions subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Functions subpath import works");
+
+import * as Expression from "../dist/functions/expression/index.js";
+if (typeof Expression !== "object" || Expression === null || Object.keys(Expression).length === 0) {
+  console.log("  ✗ Functions/Expression subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Functions/Expression subpath import works");
+
+import * as EnsembleLlm from "../dist/ensemble_llm/index.js";
+if (typeof EnsembleLlm !== "object" || EnsembleLlm === null || Object.keys(EnsembleLlm).length === 0) {
+  console.log("  ✗ EnsembleLlm subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ EnsembleLlm subpath import works");
+
+import * as Chat from "../dist/chat/index.js";
+if (typeof Chat !== "object" || Chat === null || Object.keys(Chat).length === 0) {
+  console.log("  ✗ Chat subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Chat subpath import works");
+
+import * as Vector from "../dist/vector/index.js";
+if (typeof Vector !== "object" || Vector === null || Object.keys(Vector).length === 0) {
+  console.log("  ✗ Vector subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Vector subpath import works");
+
+import * as Ensemble from "../dist/ensemble/index.js";
+if (typeof Ensemble !== "object" || Ensemble === null || Object.keys(Ensemble).length === 0) {
+  console.log("  ✗ Ensemble subpath import failed");
+  process.exit(1);
+}
+console.log("  ✓ Ensemble subpath import works");
 
 console.log("ESM: PASSED");

--- a/objectiveai-js/tsup.config.ts
+++ b/objectiveai-js/tsup.config.ts
@@ -2,33 +2,56 @@ import { defineConfig, Options } from "tsup";
 import path from "path";
 import { inlineConvertPlugin } from "./scripts/esbuild-inline-convert";
 
+// All module entry points for multi-file output
+const entry = [
+  "src/index.ts",
+  "src/auth/index.ts",
+  "src/chat/index.ts",
+  "src/chat/completions/index.ts",
+  "src/ensemble/index.ts",
+  "src/ensemble_llm/index.ts",
+  "src/functions/index.ts",
+  "src/functions/expression/index.ts",
+  "src/functions/executions/index.ts",
+  "src/functions/profiles/index.ts",
+  "src/functions/quality/index.ts",
+  "src/vector/index.ts",
+  "src/vector/completions/index.ts",
+];
+
 // Base configuration shared between formats
 const baseConfig: Options = {
-  entry: ["src/index.ts"],
-  dts: true,
+  entry,
   outDir: "dist",
   treeshake: true,
   target: "es2020",
+  minify: false,
+  keepNames: true,
   esbuildOptions(options) {
     options.alias = {
       src: path.resolve(__dirname, "src"),
     };
+    // Preserve comments (legal comments + all others)
+    options.legalComments = "inline";
   },
   esbuildPlugins: [inlineConvertPlugin()],
 };
 
 export default defineConfig([
-  // ESM build
+  // ESM build — with splitting for shared chunk deduplication
   {
     ...baseConfig,
     format: ["esm"],
+    splitting: true,
     outExtension: () => ({ js: ".js" }),
     clean: true,
+    dts: true,
   },
   // CJS build
   {
     ...baseConfig,
     format: ["cjs"],
+    splitting: false,
     outExtension: () => ({ js: ".cjs" }),
     clean: false,
     dts: false,


### PR DESCRIPTION
# Multi-file Build Output

The SDK currently ships as a few massive bundled files (~8.5MB each). This makes it really hard for coding agents (and humans) to read and understand the source when the SDK is installed as a dependency.

This PR restructures the build output to be multi-file, similar to how the OpenAI SDK distributes its package.

## What Changed

### Multi-entry Build
`tsup` now builds 13 separate entry points instead of one giant bundle. Each logical module (auth, chat, ensemble, functions, vector, etc.) gets its own output file.

### ESM Code Splitting
Shared code (WASM loader, zod schemas, utilities) is extracted into shared chunks instead of being duplicated across every entry point.

### Subpath Exports
You can now import directly from submodules:
```typescript
// This still works exactly as before
import { Functions } from "objectiveai";
let foo: Functions.Expression.InputValue;

// And now this also works
import { InputValue } from "objectiveai/functions/expression";
let foo: InputValue;
```

### `typesVersions`
Ensures type resolution works for older TypeScript versions that don't support the `exports` field.

### Tests Extended
CJS and ESM import tests now verify both namespace and subpath imports.

## What Didn't Change

- **No source code changes** — the `src/` path alias is resolved at build time by esbuild, so no import rewrites needed.
- **WASM** — loaders already use relative imports, splitting just deduplicates the base64 binary.
- **`convert()` inlining** — the precompute + esbuild plugin pipeline is completely unaffected.
- **Public API** — zero breaking changes. All existing imports continue to work.