### PR TITLE
Fix functions page 404 crash + skeleton loaders

### DIFF
--- a/objectiveai-web/app/functions/[...slug]/page.tsx
+++ b/objectiveai-web/app/functions/[...slug]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { createPublicClient } from "../../../lib/client";
 import { deriveDisplayName, DEV_EXECUTION_OPTIONS } from "../../../lib/objectiveai";
 import { PINNED_COLOR_ANIMATION_MS } from "../../../lib/constants";
+import { DEFAULT_PROFILES } from "../../../lib/profiles";
 import { loadReasoningModels } from "../../../lib/reasoning-models";
 import { useIsMobile } from "../../../hooks/useIsMobile";
 import { useObjectiveAI } from "../../../hooks/useObjectiveAI";
@@ -17,6 +18,8 @@ import { simplifySplitItems, toDisplayItem, getDisplayMode } from "../../../lib/
 import { compileFunctionInputSplit, type FunctionConfig } from "../../../lib/wasm-validation";
 import { Functions, EnsembleLlm } from "objectiveai";
 import { ObjectiveAIFetchError } from "objectiveai";
+import { SkeletonFunctionDetails } from "../../../components/ui";
+
 interface FunctionDetails {
   owner: string;
   repository: string;
@@ -48,8 +51,14 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
   const slugKey = `${owner}/${repository}`;
 
   const [functionDetails, setFunctionDetails] = useState<FunctionDetails | null>(null);
-  const [availableProfiles, setAvailableProfiles] = useState<{ owner: string; repository: string; commit: string }[]>([]);
   const [selectedProfileIndex, setSelectedProfileIndex] = useState(0);
+  const [availableProfiles, setAvailableProfiles] = useState<Array<{
+    owner: string;
+    repository: string;
+    commit: string | null;
+    label: string;
+    description: string;
+  }>>(DEFAULT_PROFILES);
   const [isLoadingDetails, setIsLoadingDetails] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -128,35 +137,6 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
         // Fetch function details directly (works for all functions, regardless of profiles)
         const details = await Functions.retrieve(publicClient, "github", owner, repository, null);
 
-        // Try to get available profiles (separately, so function loads even if no profiles exist)
-        let profiles: { owner: string; repository: string; commit: string }[] = [];
-        try {
-          const pairs = await Functions.listPairs(publicClient);
-          const matchingPairs = pairs.data.filter(
-            (p: { function: { owner: string; repository: string } }) =>
-              p.function.owner === owner && p.function.repository === repository
-          );
-          profiles = matchingPairs.map((p: { profile: { owner: string; repository: string; commit: string } }) => p.profile);
-        } catch {
-          // If pairs fetch fails, continue to fallback
-          profiles = [];
-        }
-
-        // Fallback: try fetching profile from same repo (CLI puts profile.json in the function repo)
-        if (profiles.length === 0) {
-          try {
-            const profile = await Functions.Profiles.retrieve(publicClient, "github", owner, repository, null);
-            profiles = [{ owner, repository, commit: profile.commit }];
-          } catch {
-            // Genuinely no profile exists for this function
-          }
-        }
-
-        setAvailableProfiles(profiles);
-        if (profiles.length > 0) {
-          setSelectedProfileIndex(0);
-        }
-
         const category = details.type === "vector.function" ? "Ranking" : "Scoring";
 
         setFunctionDetails({
@@ -169,6 +149,48 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
           type: details.type as "scalar.function" | "vector.function",
           inputSchema: (details as { input_schema?: Record<string, unknown> }).input_schema || null,
         });
+
+        // Try to get available profiles (separately, so function loads even if no profiles exist)
+        let functionProfiles: Array<{ owner: string; repository: string; commit: string; label: string; description: string }> = [];
+        try {
+          const pairs = await Functions.listPairs(publicClient);
+          const matchingPairs = pairs.data.filter(
+            (p: { function: { owner: string; repository: string } }) =>
+              p.function.owner === owner && p.function.repository === repository
+          );
+          functionProfiles = matchingPairs.map(
+            (p: { profile: { owner: string; repository: string; commit: string } }) => ({
+              owner: p.profile.owner,
+              repository: p.profile.repository,
+              commit: p.profile.commit,
+              label: deriveDisplayName(p.profile.repository),
+              description: `${p.profile.owner}/${p.profile.repository}`,
+            })
+          );
+        } catch {
+          // If pairs fetch fails, continue to fallback
+          functionProfiles = [];
+        }
+
+        // Fallback: try fetching profile from same repo (CLI puts profile.json in the function repo)
+        if (functionProfiles.length === 0) {
+          try {
+            const profile = await Functions.Profiles.retrieve(publicClient, "github", owner, repository, null);
+            functionProfiles = [{
+              owner,
+              repository,
+              commit: profile.commit,
+              label: deriveDisplayName(repository),
+              description: `${owner}/${repository}`,
+            }];
+          } catch {
+            // Genuinely no profile exists for this function
+          }
+        }
+
+        // Function-specific profiles first, then defaults
+        setAvailableProfiles([...functionProfiles, ...DEFAULT_PROFILES]);
+        setSelectedProfileIndex(0);
       } catch (err) {
         setLoadError(err instanceof Error ? err.message : "Failed to load function");
       } finally {
@@ -697,22 +719,7 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
 
   // Loading state
   if (isLoadingDetails) {
-    return (
-      <div className="page">
-        <div className="container" style={{ paddingTop: "100px", textAlign: "center" }}>
-          <div style={{
-            width: "40px",
-            height: "40px",
-            border: "3px solid var(--border)",
-            borderTopColor: "var(--accent)",
-            borderRadius: "50%",
-            margin: "0 auto 16px",
-            animation: "spin 1s linear infinite",
-          }} />
-          <p style={{ color: "var(--text-muted)" }}>Loading function...</p>
-        </div>
-      </div>
-    );
+    return <SkeletonFunctionDetails />;
   }
 
   // Error state
@@ -824,47 +831,45 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
               {renderInputFields()}
             </div>
 
-            {availableProfiles.length > 1 && (
-              <div style={{ marginTop: isMobile ? "16px" : "24px" }}>
-                <label style={{
-                  display: "block",
-                  fontSize: "14px",
-                  fontWeight: 600,
-                  marginBottom: "8px",
-                  color: "var(--text)",
+            <div style={{ marginTop: isMobile ? "16px" : "24px" }}>
+              <label style={{
+                display: "block",
+                fontSize: "14px",
+                fontWeight: 600,
+                marginBottom: "8px",
+                color: "var(--text)",
+              }}>
+                Profile
+                <span style={{
+                  fontWeight: 400,
+                  color: "var(--text-muted)",
+                  marginLeft: "8px",
                 }}>
-                  Profile
-                  <span style={{
-                    fontWeight: 400,
-                    color: "var(--text-muted)",
-                    marginLeft: "8px",
-                  }}>
-                    Learned weights for this function
-                  </span>
-                </label>
-                <select
-                  className="select"
-                  value={selectedProfileIndex}
-                  onChange={(e) => setSelectedProfileIndex(parseInt(e.target.value, 10))}
-                  style={{
-                    width: "100%",
-                    padding: isMobile ? "10px 12px" : "12px 16px",
-                    fontSize: isMobile ? "14px" : "15px",
-                    background: "var(--page-bg)",
-                    border: "1px solid var(--border)",
-                    borderRadius: "8px",
-                    color: "var(--text)",
-                    cursor: "pointer",
-                  }}
-                >
-                  {availableProfiles.map((profile, idx) => (
-                    <option key={`${profile.owner}/${profile.repository}@${profile.commit}`} value={idx}>
-                      {profile.owner}/{profile.repository}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
+                  Learned weights for this function
+                </span>
+              </label>
+              <select
+                className="select"
+                value={selectedProfileIndex}
+                onChange={(e) => setSelectedProfileIndex(parseInt(e.target.value, 10))}
+                style={{
+                  width: "100%",
+                  padding: isMobile ? "10px 12px" : "12px 16px",
+                  fontSize: isMobile ? "14px" : "15px",
+                  background: "var(--page-bg)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "8px",
+                  color: "var(--text)",
+                  cursor: "pointer",
+                }}
+              >
+                {availableProfiles.map((profile, idx) => (
+                  <option key={`${profile.owner}/${profile.repository}`} value={idx}>
+                    {profile.label} — {profile.description}
+                  </option>
+                ))}
+              </select>
+            </div>
 
             {/* Reasoning Options */}
             <div style={{
@@ -981,27 +986,16 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
             <button
               className="pillBtn"
               onClick={handleRun}
-              disabled={isRunning || availableProfiles.length === 0}
+              disabled={isRunning}
               style={{
                 width: "100%",
                 marginTop: isMobile ? "20px" : "32px",
                 padding: isMobile ? "12px 16px" : undefined,
-                opacity: (isRunning || availableProfiles.length === 0) ? 0.7 : 1,
+                opacity: isRunning ? 0.7 : 1,
               }}
             >
-              {isRunning ? "Running..." : availableProfiles.length === 0 ? "No Profile Available" : "Execute"}
+              {isRunning ? "Running..." : "Execute"}
             </button>
-            {availableProfiles.length === 0 && !isLoadingDetails && (
-              <p style={{
-                fontSize: "12px",
-                color: "var(--text-muted)",
-                marginTop: "8px",
-                textAlign: "center",
-                lineHeight: 1.4,
-              }}>
-                This function has no profile yet. A profile with learned weights is required for execution.
-              </p>
-            )}
           </div>
 
           {/* Right - Results */}
@@ -1328,6 +1322,7 @@ export default function FunctionDetailPage({ params }: { params: Promise<{ slug:
             )}
           </div>
         </div>
+
       </div>
     </div>
   );

--- a/objectiveai-web/components/SchemaForm/SchemaFormBuilder.tsx
+++ b/objectiveai-web/components/SchemaForm/SchemaFormBuilder.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useCallback, useMemo } from "react";
 import type { SchemaFormBuilderProps, ValidationError } from "./types";
 import { validateValue } from "./validation";
-import { getDefaultValue } from "./utils";
+import { getDefaultValue, valueMatchesSchema } from "./utils";
 import SchemaField from "./SchemaField";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
@@ -52,7 +52,7 @@ export default function SchemaFormBuilder({
 
   // Initialize with default values if value is null/undefined
   const effectiveValue = useMemo(() => {
-    if (value === null || value === undefined) {
+    if (value === null || value === undefined || !valueMatchesSchema(value, schema)) {
       return getDefaultValue(schema);
     }
     return value;

--- a/objectiveai-web/components/SchemaForm/fields/ArrayField.tsx
+++ b/objectiveai-web/components/SchemaForm/fields/ArrayField.tsx
@@ -19,7 +19,7 @@ export default function ArrayField({
   isMobile,
   depth = 0,
 }: ArrayFieldProps) {
-  const items = value ?? [];
+  const items = Array.isArray(value) ? value : [];
   const canAdd = schema.maxItems == null || items.length < schema.maxItems;
   const canRemove = items.length > (schema.minItems ?? 0);
 

--- a/objectiveai-web/components/ui/SkeletonCard.tsx
+++ b/objectiveai-web/components/ui/SkeletonCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Skeleton loading placeholder for function cards on the browse page.
+ * Matches the dimensions of a rendered function card.
+ */
+export function SkeletonCard() {
+  return (
+    <div className="card" style={{
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      padding: "16px",
+    }}>
+      {/* Category tag */}
+      <div className="skeleton" style={{
+        alignSelf: "flex-start",
+        marginBottom: "8px",
+        height: "22px",
+        width: "60px",
+        borderRadius: "4px",
+      }} />
+      {/* Title */}
+      <div className="skeleton" style={{
+        height: "20px",
+        width: "80%",
+        marginBottom: "12px",
+        borderRadius: "4px",
+      }} />
+      {/* Description lines */}
+      <div style={{ flex: 1, marginBottom: "12px" }}>
+        <div className="skeleton" style={{ height: "14px", width: "100%", marginBottom: "6px", borderRadius: "4px" }} />
+        <div className="skeleton" style={{ height: "14px", width: "90%", marginBottom: "6px", borderRadius: "4px" }} />
+        <div className="skeleton" style={{ height: "14px", width: "60%", borderRadius: "4px" }} />
+      </div>
+      {/* Tags */}
+      <div style={{ display: "flex", gap: "4px", marginBottom: "14px" }}>
+        <div className="skeleton" style={{ height: "18px", width: "50px", borderRadius: "10px" }} />
+        <div className="skeleton" style={{ height: "18px", width: "70px", borderRadius: "10px" }} />
+      </div>
+      {/* Open link */}
+      <div className="skeleton" style={{ height: "16px", width: "60px", borderRadius: "4px" }} />
+    </div>
+  );
+}

--- a/objectiveai-web/components/ui/SkeletonFunctionDetails.tsx
+++ b/objectiveai-web/components/ui/SkeletonFunctionDetails.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useIsMobile } from "../../hooks/useIsMobile";
+
+/**
+ * Full-page skeleton for the function detail page.
+ * Matches the layout of a loaded function page.
+ */
+export function SkeletonFunctionDetails() {
+  const isMobile = useIsMobile();
+
+  return (
+    <div className="page">
+      <div className="container" style={{ paddingTop: isMobile ? "24px" : "32px" }}>
+        {/* Breadcrumbs */}
+        <div style={{ display: "flex", gap: "8px", marginBottom: "20px" }}>
+          <div className="skeleton" style={{ width: "70px", height: "20px", borderRadius: "4px" }} />
+          <span style={{ color: "var(--text-muted)" }}>/</span>
+          <div className="skeleton" style={{ width: "140px", height: "20px", borderRadius: "4px" }} />
+        </div>
+        {/* Title */}
+        <div className="skeleton" style={{
+          height: isMobile ? "28px" : "36px",
+          width: "60%",
+          marginBottom: "12px",
+          borderRadius: "6px",
+        }} />
+        {/* Description */}
+        <div className="skeleton" style={{ height: "16px", width: "90%", marginBottom: "6px", borderRadius: "4px" }} />
+        <div className="skeleton" style={{ height: "16px", width: "70%", marginBottom: "24px", borderRadius: "4px" }} />
+        {/* Tags row */}
+        <div style={{ display: "flex", gap: "8px", marginBottom: "32px" }}>
+          <div className="skeleton" style={{ height: "24px", width: "80px", borderRadius: "12px" }} />
+          <div className="skeleton" style={{ height: "24px", width: "60px", borderRadius: "12px" }} />
+          <div className="skeleton" style={{ height: "24px", width: "90px", borderRadius: "12px" }} />
+        </div>
+        {/* Input area */}
+        <div className="skeleton" style={{
+          height: "200px",
+          width: "100%",
+          borderRadius: "12px",
+          marginBottom: "24px",
+        }} />
+        {/* Button */}
+        <div className="skeleton" style={{
+          height: "44px",
+          width: isMobile ? "100%" : "200px",
+          borderRadius: "8px",
+        }} />
+      </div>
+    </div>
+  );
+}

--- a/objectiveai-web/components/ui/index.ts
+++ b/objectiveai-web/components/ui/index.ts
@@ -15,3 +15,5 @@ export { LoadingSpinner } from "./LoadingSpinner";
 export { ErrorAlert } from "./ErrorAlert";
 export { EmptyState } from "./EmptyState";
 export { FormField } from "./FormField";
+export { SkeletonCard } from "./SkeletonCard";
+export { SkeletonFunctionDetails } from "./SkeletonFunctionDetails";

--- a/objectiveai-web/lib/profiles.ts
+++ b/objectiveai-web/lib/profiles.ts
@@ -1,0 +1,47 @@
+export interface DefaultProfile {
+  owner: string;
+  repository: string;
+  commit: null;
+  label: string;
+  description: string;
+}
+
+export const DEFAULT_PROFILES: DefaultProfile[] = [
+  {
+    owner: "ObjectiveAI",
+    repository: "profile-nano",
+    commit: null,
+    label: "Nano",
+    description: "4 non-reasoning LLMs, horizontal scaling",
+  },
+  {
+    owner: "ObjectiveAI",
+    repository: "profile-mini",
+    commit: null,
+    label: "Mini",
+    description: "3x nano, stronger consensus",
+  },
+  {
+    owner: "ObjectiveAI",
+    repository: "profile-standard",
+    commit: null,
+    label: "Standard",
+    description: "Mini's base + 5 reasoning LLMs",
+  },
+  {
+    owner: "ObjectiveAI",
+    repository: "profile-giga",
+    commit: null,
+    label: "Giga",
+    description: "Standard + frontier models",
+  },
+  {
+    owner: "ObjectiveAI",
+    repository: "profile-giga-max",
+    commit: null,
+    label: "Giga Max",
+    description: "3x frontier models, lightweight tie-breakers",
+  },
+];
+
+export const DEFAULT_PROFILE_INDEX = 0; // Nano


### PR DESCRIPTION
## Summary

- **Fix: Functions page 404 crash** — `Promise.all` rejected entirely when any single `Functions.retrieve()` returned 404 (e.g. deleted repo). Now each retrieve is wrapped in try/catch; failed functions are filtered out. Applied to `/functions` and homepage.
- **Fix: Array input crash** (#115) — Functions with array-type input schemas crashed SchemaFormBuilder.
- **Add skeleton loaders** — Shimmer cards on browse page, full skeleton on detail page. Concept from @hozi8-web3 (#101).
- **Add default profiles** — 5 built-in profiles (Nano → Giga Max) auto-selected when no function-specific profile exists.

## Test plan

- [ ] `/functions` loads even if some functions 404
- [ ] Function detail page shows skeleton during load
- [ ] Execute a function with default profile
- [ ] Test a function with array inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)