### PR TITLE
message-queue: `--key` upsert for enqueued items (closes #213)

### DIFF
--- a/objectiveai-cli/src/command/agents/message_queue/add.rs
+++ b/objectiveai-cli/src/command/agents/message_queue/add.rs
@@ -45,6 +45,7 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<Response, Error>
         ctx.filesystem.clone(),
         agent_instance_hierarchy.clone(),
         agent_tag.clone(),
+        request.key,
         content,
     )
     .await?;

--- a/objectiveai-cli/src/command/agents/message_queue/delete.rs
+++ b/objectiveai-cli/src/command/agents/message_queue/delete.rs
@@ -23,6 +23,7 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<Response, Error>
         id: request.id,
         agent_instance_hierarchy: item.agent_instance_hierarchy,
         agent_tag: item.agent_tag,
+        key: item.key,
         enqueued_at: item.enqueued_at,
         content: item.content,
     })

--- a/objectiveai-cli/src/filesystem/db/prompts.rs
+++ b/objectiveai-cli/src/filesystem/db/prompts.rs
@@ -252,6 +252,7 @@ pub async fn enqueue_with_content_async(
     client: Client,
     agent_instance_hierarchy: Option<String>,
     agent_tag: Option<String>,
+    key: Option<String>,
     content: RichContent,
 ) -> Result<i64, Error> {
     tokio::task::spawn_blocking(move || {
@@ -259,6 +260,7 @@ pub async fn enqueue_with_content_async(
             &client,
             agent_instance_hierarchy.as_deref(),
             agent_tag.as_deref(),
+            key.as_deref(),
             content,
         )
     })
@@ -270,6 +272,7 @@ fn enqueue_with_content(
     client: &Client,
     agent_instance_hierarchy: Option<&str>,
     agent_tag: Option<&str>,
+    key: Option<&str>,
     content: RichContent,
 ) -> Result<i64, Error> {
     let conn = super::tags::connection(client)?;
@@ -281,6 +284,7 @@ fn enqueue_with_content(
         &tx,
         agent_instance_hierarchy,
         agent_tag,
+        key,
         now_seconds(),
         content,
     )?;
@@ -298,17 +302,38 @@ fn enqueue_with_content_in_tx(
     tx: &rusqlite::Transaction<'_>,
     agent_instance_hierarchy: Option<&str>,
     agent_tag: Option<&str>,
+    key: Option<&str>,
     enqueued_at: i64,
     content: RichContent,
 ) -> Result<i64, Error> {
+    if let Some(key_value) = key {
+        // Upsert: drop any prior row for this (target, key) pair so
+        // the partial unique index never trips. Cascade on
+        // `prompt_contents.prompt_id` sweeps the prior row's
+        // content rows in the same transaction.
+        tx.execute(
+            "DELETE FROM prompts \
+             WHERE key = ?3 \
+               AND ( \
+                   (agent_instance_hierarchy IS NOT NULL \
+                    AND ?1 IS NOT NULL \
+                    AND agent_instance_hierarchy = ?1) \
+                   OR \
+                   (agent_tag IS NOT NULL \
+                    AND ?2 IS NOT NULL \
+                    AND agent_tag = ?2) \
+               )",
+            params![agent_instance_hierarchy, agent_tag, key_value],
+        )?;
+    }
     // Empty `prompt` placeholder Ã¢â‚¬â€ overwritten by the final UPDATE
     // once we know the id-referenced shape. `prompts.prompt` is
     // NOT NULL so we need *some* value here.
     let prompt_id: i64 = tx.query_row(
-        "INSERT INTO prompts (agent_instance_hierarchy, agent_tag, prompt, enqueued_at) \
-         VALUES (?1, ?2, '', ?3) \
+        "INSERT INTO prompts (agent_instance_hierarchy, agent_tag, prompt, enqueued_at, key) \
+         VALUES (?1, ?2, '', ?3, ?4) \
          RETURNING id",
-        params![agent_instance_hierarchy, agent_tag, enqueued_at],
+        params![agent_instance_hierarchy, agent_tag, enqueued_at, key],
         |r| r.get(0),
     )?;
     let response_content = walk_rich(tx, prompt_id, content)?;
@@ -491,6 +516,7 @@ pub fn list(client: &Client, parent: &str) -> Result<Vec<ResponseItem>, Error> {
         "SELECT p.id, \
                 p.agent_instance_hierarchy, \
                 p.agent_tag, \
+                p.key, \
                 p.prompt, \
                 t.agent_instance_hierarchy        AS tag_bound_hierarchy, \
                 t.parent_agent_instance_hierarchy AS tag_pending_parent, \
@@ -524,10 +550,11 @@ pub fn list(client: &Client, parent: &str) -> Result<Vec<ResponseItem>, Error> {
                 r.get::<_, i64>(0)?,
                 r.get::<_, Option<String>>(1)?,
                 r.get::<_, Option<String>>(2)?,
-                r.get::<_, String>(3)?,
-                r.get::<_, Option<String>>(4)?,
+                r.get::<_, Option<String>>(3)?,
+                r.get::<_, String>(4)?,
                 r.get::<_, Option<String>>(5)?,
                 r.get::<_, Option<String>>(6)?,
+                r.get::<_, Option<String>>(7)?,
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -537,6 +564,7 @@ pub fn list(client: &Client, parent: &str) -> Result<Vec<ResponseItem>, Error> {
         id,
         agent_instance_hierarchy,
         agent_tag,
+        key,
         prompt_json,
         tag_bound_hierarchy,
         tag_pending_parent,
@@ -561,6 +589,7 @@ pub fn list(client: &Client, parent: &str) -> Result<Vec<ResponseItem>, Error> {
             out.push(ResponseItem::AgentInstance {
                 id,
                 agent_instance,
+                key,
                 content,
             });
         } else if let Some(tag) = agent_tag {
@@ -583,6 +612,7 @@ pub fn list(client: &Client, parent: &str) -> Result<Vec<ResponseItem>, Error> {
                 id,
                 agent_tag: tag,
                 state,
+                key,
                 content,
             });
         } else {
@@ -622,6 +652,10 @@ pub struct DrainedPrompt {
     /// Original `prompts.agent_tag`; `Some` when the drained row
     /// was Tag-targeted.
     pub agent_tag: Option<String>,
+    /// Original `prompts.key`. Preserved through re-enqueue so a
+    /// failed delivery doesn't lose the idempotency token (#213).
+    /// `None` for unkeyed rows.
+    pub key: Option<String>,
     /// Original `prompts.enqueued_at`. Preserved through re-enqueue
     /// so FIFO ordering survives a drain Ã¢â€ â€™ fail Ã¢â€ â€™ re-enqueue cycle.
     pub enqueued_at: i64,
@@ -752,6 +786,7 @@ struct DrainedRow {
     prompt_id: i64,
     agent_instance_hierarchy: Option<String>,
     agent_tag: Option<String>,
+    key: Option<String>,
     enqueued_at: i64,
     prompt_json: String,
 }
@@ -768,6 +803,7 @@ fn collect_matching_prompts(
         "SELECT p.id, \
                 p.agent_instance_hierarchy, \
                 p.agent_tag, \
+                p.key, \
                 p.enqueued_at, \
                 p.prompt \
          FROM prompts p \
@@ -781,8 +817,9 @@ fn collect_matching_prompts(
                 prompt_id: r.get(0)?,
                 agent_instance_hierarchy: r.get(1)?,
                 agent_tag: r.get(2)?,
-                enqueued_at: r.get(3)?,
-                prompt_json: r.get(4)?,
+                key: r.get(3)?,
+                enqueued_at: r.get(4)?,
+                prompt_json: r.get(5)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -818,6 +855,7 @@ fn reconstruct_and_delete(
         out.push(DrainedPrompt {
             agent_instance_hierarchy: row.agent_instance_hierarchy,
             agent_tag: row.agent_tag,
+            key: row.key,
             enqueued_at: row.enqueued_at,
             content,
         });
@@ -899,6 +937,7 @@ fn re_enqueue(client: &Client, items: Vec<DrainedPrompt>) -> Result<(), Error> {
             &tx,
             item.agent_instance_hierarchy.as_deref(),
             item.agent_tag.as_deref(),
+            item.key.as_deref(),
             item.enqueued_at,
             item.content,
         )?;

--- a/objectiveai-cli/src/filesystem/db/tags.rs
+++ b/objectiveai-cli/src/filesystem/db/tags.rs
@@ -83,6 +83,7 @@ fn init_tables(conn: &Connection) -> Result<(), Error> {
             agent_tag                TEXT, \
             prompt                   TEXT NOT NULL, \
             enqueued_at              INTEGER NOT NULL, \
+            key                      TEXT, \
             CHECK ( \
                 (agent_instance_hierarchy IS NOT NULL AND agent_tag IS NULL) \
                 OR \
@@ -95,6 +96,17 @@ fn init_tables(conn: &Connection) -> Result<(), Error> {
         CREATE INDEX IF NOT EXISTS prompts_tag_idx \
             ON prompts(agent_tag, id) \
             WHERE agent_tag IS NOT NULL;\
+        /* Partial unique indexes scope `key` uniqueness per target. \
+           A second `agents message-queue add` with the same \
+           (target, key) is upserted by the storage helper (explicit \
+           DELETE + INSERT). NULL keys are excluded from the index, \
+           so unkeyed items remain append-only. */ \
+        CREATE UNIQUE INDEX IF NOT EXISTS prompts_key_hierarchy_unique_idx \
+            ON prompts(agent_instance_hierarchy, key) \
+            WHERE agent_instance_hierarchy IS NOT NULL AND key IS NOT NULL;\
+        CREATE UNIQUE INDEX IF NOT EXISTS prompts_key_tag_unique_idx \
+            ON prompts(agent_tag, key) \
+            WHERE agent_tag IS NOT NULL AND key IS NOT NULL;\
         CREATE TABLE IF NOT EXISTS prompt_contents (\
             id        INTEGER PRIMARY KEY AUTOINCREMENT, \
             prompt_id INTEGER NOT NULL, \
@@ -136,6 +148,18 @@ fn init_tables(conn: &Connection) -> Result<(), Error> {
         );\
         ",
     )?;
+    // Defensive migration for `tags.sqlite` files that predate the
+    // `prompts.key` column (#213). New databases already have the
+    // column from the CREATE TABLE above; for existing ones, ALTER
+    // adds it. SQLite reports a SQLITE_ERROR ("duplicate column
+    // name: key") when the column is already present — treat that
+    // as a no-op, propagate anything else.
+    if let Err(e) = conn.execute("ALTER TABLE prompts ADD COLUMN key TEXT", []) {
+        let msg = e.to_string();
+        if !msg.contains("duplicate column name") {
+            return Err(e.into());
+        }
+    }
     Ok(())
 }
 

--- a/objectiveai-sdk-rs/src/cli/command/agents/message_queue/add/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/message_queue/add/mod.rs
@@ -25,6 +25,14 @@ pub struct Request {
     pub path_type: Path,
     pub target: Target,
     pub message: super::super::message::RequestMessage,
+    /// Optional idempotency token (#213). When `Some`, any prior
+    /// queued row for the same `(target, key)` pair is overwritten
+    /// — old content cascade-dropped, new content inserted with a
+    /// fresh `enqueued_at`. Per-target scope: a `key` on a
+    /// hierarchy and the same `key` on a tag coexist.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("omitempty" = true))]
+    pub key: Option<String>,
     pub jq: Option<String>,
 }
 
@@ -82,6 +90,10 @@ impl CommandRequest for Request {
             }
         }
         self.message.push_flags(&mut argv);
+        if let Some(key) = &self.key {
+            argv.push("--key".to_string());
+            argv.push(key.clone());
+        }
         if let Some(jq) = &self.jq {
             argv.push("--jq".to_string());
             argv.push(jq.clone());
@@ -132,6 +144,12 @@ pub struct Args {
     /// `--file` / `--python-inline` / `--python-file`). Required.
     #[command(flatten)]
     pub message: super::super::message::MessageArgs,
+    /// Optional idempotency token. When set, a second `add` with
+    /// the same `(target, key)` overwrites the prior queued row
+    /// instead of stacking a new one. Per-target scope — a key on
+    /// a hierarchy and the same key on a tag coexist.
+    #[arg(long)]
+    pub key: Option<String>,
     /// jq filter applied to the JSON output.
     #[arg(long)]
     pub jq: Option<String>,
@@ -192,6 +210,7 @@ impl TryFrom<Args> for Request {
             path_type: Path::AgentsQueueAdd,
             target,
             message,
+            key: args.key,
             jq: args.jq,
         })
     }

--- a/objectiveai-sdk-rs/src/cli/command/agents/message_queue/delete/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/message_queue/delete/mod.rs
@@ -56,6 +56,10 @@ pub struct Response {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub agent_tag: Option<String>,
+    /// Idempotency token, if the dropped row had one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("omitempty" = true))]
+    pub key: Option<String>,
     pub enqueued_at: i64,
     pub content: crate::agent::completions::message::RichContent,
 }

--- a/objectiveai-sdk-rs/src/cli/command/agents/message_queue/read/pending/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/message_queue/read/pending/mod.rs
@@ -73,6 +73,11 @@ pub enum ResponseItem {
     AgentInstance {
         id: i64,
         agent_instance: String,
+        /// Idempotency token, if the row was enqueued with `--key`.
+        /// Skipped from the wire shape when `None`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(extend("omitempty" = true))]
+        key: Option<String>,
         content: super::super::super::read::all::ResponseContent,
     },
     #[schemars(title = "Tag")]
@@ -81,6 +86,10 @@ pub enum ResponseItem {
         agent_tag: String,
         #[serde(flatten)]
         state: LookupState,
+        /// Idempotency token, if the row was enqueued with `--key`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(extend("omitempty" = true))]
+        key: Option<String>,
         content: super::super::super::read::all::ResponseContent,
     },
 }


### PR DESCRIPTION
## Summary

Closes #213. Adds an optional `--key <name>` token to `agents message-queue add` so a second add with the same `(target, key)` **overwrites** the prior queued row's content and refreshes `enqueued_at`. Unkeyed items remain append-only. Per-target scope — a key on a hierarchy and the same key on a tag coexist.

## CLI surface

```
agents message-queue add <leaf> --simple "buy 5 widgets" --key buy-widgets
# later, before drain:
agents message-queue add <leaf> --simple "buy 7 widgets" --key buy-widgets
# read pending shows one row with content "buy 7 widgets", newer enqueued_at
agents message-queue read pending
# delete returns the key on the dropped row's Response
agents message-queue delete <id>
```

`read pending` ResponseItem variants (`AgentInstance` / `Tag`) and `delete` Response struct each grow `key: Option<String>` (`skip_serializing_if = Option::is_none`).

## Schema

`prompts` gains `key TEXT NULL`. Two partial unique indexes scope uniqueness per target:

```sql
CREATE UNIQUE INDEX prompts_key_hierarchy_unique_idx
    ON prompts(agent_instance_hierarchy, key)
    WHERE agent_instance_hierarchy IS NOT NULL AND key IS NOT NULL;
CREATE UNIQUE INDEX prompts_key_tag_unique_idx
    ON prompts(agent_tag, key)
    WHERE agent_tag IS NOT NULL AND key IS NOT NULL;
```

Defensive `ALTER TABLE prompts ADD COLUMN key TEXT` in `init_tables` migrates existing databases — duplicate-column error treated as no-op.

## Storage delta

`db::prompts::enqueue_with_content_in_tx` gains `key: Option<&str>`. When `Some`, it runs explicit `DELETE FROM prompts WHERE key = ? AND (target match)` before the INSERT — cascade on `prompt_contents.prompt_id` sweeps the prior row's content rows in the same transaction. Explicit DELETE+INSERT rather than `INSERT OR REPLACE` keeps the FK cascade ordering tractable.

`DrainedPrompt` and `DrainedRow` gain `key: Option<String>` so re-enqueue restores the token on a spawn/message failure. Drain predicates themselves don't change — keys are about uniqueness at insertion, not at delivery.

## Test plan

- [x] `cargo check -p objectiveai-sdk -p objectiveai-cli` clean.
- [ ] Manual smoke (post-rebuild):
  - Unkeyed adds stay append-only.
  - Two keyed adds with same `(hierarchy, key)` → one row, latest content, updated `enqueued_at`.
  - Two keyed adds with same key but different targets coexist.
  - Two keyed adds with same target but different keys coexist.
  - Drain in `agents message` / `agents spawn` sweeps keyed rows normally; re-enqueue on failure restores both `key` and original `enqueued_at`.
  - `delete <id>` Response shows the `key` of the dropped row.
  - Migration: open an existing pre-key `tags.sqlite` → ALTER adds the column; subsequent opens are no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)