### PR TITLE
cli: drop `prompts.key` ALTER migration

### DIFF
--- a/objectiveai-cli/src/filesystem/db/tags.rs
+++ b/objectiveai-cli/src/filesystem/db/tags.rs
@@ -148,18 +148,6 @@ fn init_tables(conn: &Connection) -> Result<(), Error> {
         );\
         ",
     )?;
-    // Defensive migration for `tags.sqlite` files that predate the
-    // `prompts.key` column (#213). New databases already have the
-    // column from the CREATE TABLE above; for existing ones, ALTER
-    // adds it. SQLite reports a SQLITE_ERROR ("duplicate column
-    // name: key") when the column is already present — treat that
-    // as a no-op, propagate anything else.
-    if let Err(e) = conn.execute("ALTER TABLE prompts ADD COLUMN key TEXT", []) {
-        let msg = e.to_string();
-        if !msg.contains("duplicate column name") {
-            return Err(e.into());
-        }
-    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Removes the defensive `ALTER TABLE prompts ADD COLUMN key TEXT` from `init_tables` (added in #214). No existing `tags.sqlite` files need migrating.

## Test plan

- [x] `cargo check -p objectiveai-sdk -p objectiveai-cli` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)