### PR TITLE
cli: tasks rework — versioned schedules, runs+logs, Target-pattern list, queue deliver

### DIFF
--- a/objectiveai-cli/src/command/agents/instances/list.rs
+++ b/objectiveai-cli/src/command/agents/instances/list.rs
@@ -3,10 +3,11 @@
 //! count, spawn/active timestamps, total logged messages). Backed by
 //! `db::instances::list_under_parent`.
 
-use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::pin::Pin;
 
-use futures::Stream;
+use futures::stream::FuturesUnordered;
+use futures::{Stream, StreamExt};
 use objectiveai_sdk::cli::command::agents::instances::list::{Request, ResponseItem};
 
 use crate::context::Context;
@@ -16,34 +17,44 @@ type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>
 
 pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Error> {
     let default_parent = ctx.config.agent_instance_hierarchy.clone();
-
-    // Resolve each target to a parent AIH whose direct children get
-    // listed. GROUPED/ABSENT tags resolve to None and are skipped.
-    let mut parents: Vec<String> = Vec::new();
-    for target in request.targets {
-        if let Some(parent) =
-            super::resolve_target(&ctx.db, target, &default_parent).await?
-        {
-            if !parents.contains(&parent) {
-                parents.push(parent);
+    let db = ctx.db.clone();
+    let stream = async_stream::stream! {
+        // Resolve + query every target concurrently. GROUPED/ABSENT tags
+        // resolve to None and contribute nothing.
+        let mut inflight = FuturesUnordered::new();
+        for target in request.targets {
+            let db = db.clone();
+            let default_parent = default_parent.clone();
+            inflight.push(async move {
+                let parent = super::resolve_target(&db, target, &default_parent).await?;
+                let items = match parent {
+                    Some(p) => crate::db::instances::list_under_parent(&db, &p)
+                        .await
+                        .map_err(Error::from)?,
+                    None => Vec::new(),
+                };
+                Ok::<Vec<ResponseItem>, Error>(items)
+            });
+        }
+        // Yield each child the moment its target's query lands — never
+        // waiting for the slowest. A `seen` set dedups by AIH across
+        // overlapping/nested targets (the BTreeMap's old job, minus the
+        // global sort that collecting would have forced).
+        let mut seen = HashSet::new();
+        while let Some(result) = inflight.next().await {
+            match result {
+                Ok(items) => {
+                    for item in items {
+                        if seen.insert(item.agent_instance_hierarchy.clone()) {
+                            yield Ok(item);
+                        }
+                    }
+                }
+                Err(e) => yield Err(e),
             }
         }
-    }
-
-    // Query each parent's direct children and merge by AIH. The
-    // BTreeMap keeps the output sorted and deduped across
-    // overlapping/nested targets.
-    let mut merged: BTreeMap<String, ResponseItem> = BTreeMap::new();
-    for parent in parents {
-        let items = crate::db::instances::list_under_parent(&ctx.db, &parent).await?;
-        for item in items {
-            merged.insert(item.agent_instance_hierarchy.clone(), item);
-        }
-    }
-
-    let items: Vec<Result<ResponseItem, Error>> =
-        merged.into_values().map(Ok).collect();
-    Ok(Box::pin(futures::stream::iter(items)))
+    };
+    Ok(Box::pin(stream))
 }
 
 pub mod request_schema {

--- a/objectiveai-cli/src/command/agents/queue/deliver.rs
+++ b/objectiveai-cli/src/command/agents/queue/deliver.rs
@@ -1,0 +1,291 @@
+//! `agents queue deliver` — wake every queue-pending strict
+//! descendant of the caller.
+//!
+//! Targets come from `db::message_queue::list_delivery_targets`
+//! (DISTINCT AIHs with active queued prompts in the caller's subtree,
+//! direct + tag-resolved), deduped and with the caller itself
+//! excluded. Per AIH, [`deliver_one`] try-acquires the agent's lock
+//! file with no waiting:
+//!
+//! - lock held by a live owner → `AgentActive {aih}` — the agent is
+//!   already running and will drain its own queue;
+//! - lock won → `AgentSpawned {aih}`, then the SAME spawn machinery
+//!   `agents spawn` / `agents message` use (`spawn::run_multi_pass`,
+//!   empty messages, the stored continuation) streams the agent's
+//!   output as `Value {aih, value}` envelopes. Ownership of the
+//!   `LockClaim` transfers into the per-AIH stream's closure, so the
+//!   lock is released the moment THAT task's stream ends — never held
+//!   for the slowest. (`run_multi_pass`'s internal registry
+//!   `observe` is best-effort and silently no-ops on the held lock.)
+//!
+//! Each per-AIH stream's FIRST item is always its resolution
+//! (`AgentActive` / `AgentSpawned` / a setup `Err`); once every
+//! target has resolved, the bare string `"AllAgentsActive"` is
+//! emitted mid-stream and spawn output keeps flowing after it.
+//!
+//! Mode split on `dangerous_advanced.stream_spawns` (mirrors
+//! `agents spawn`'s `stream`): unset/false re-execs this binary as a
+//! DETACHED ORPHAN with `stream_spawns=true` and yields the child's
+//! status items (spawn `Value` output is skipped) up to and including
+//! `AllAgentsActive`, then returns — the orphan keeps running the
+//! spawns to completion.
+
+use std::collections::HashSet;
+use std::pin::Pin;
+
+use futures::{Stream, StreamExt};
+use objectiveai_sdk::agent::completions::request::AgentCompletionCreateParams;
+use objectiveai_sdk::cli::command::agents::ResponseItem as AgentsResponseItem;
+use objectiveai_sdk::cli::command::agents::queue::deliver::{
+    AgentActiveResponseItem, AgentActiveType, AgentSpawnedResponseItem, AgentSpawnedType,
+    AllAgentsActive, Request, RequestDangerousAdvanced, ResponseItem, ValueResponseItem,
+};
+use objectiveai_sdk::cli::command::ResponseItem as RootResponseItem;
+use objectiveai_sdk::cli::command::{BinaryExecutor, CommandExecutor};
+
+use crate::context::Context;
+use crate::db;
+use crate::error::Error;
+use crate::lock_file;
+
+type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
+
+/// Internal merge item: each per-AIH stream is tagged with its index
+/// so the outer driver can tell when every target has resolved (each
+/// stream's first item is its resolution by construction).
+type TaggedStream =
+    Pin<Box<dyn Stream<Item = (usize, Result<ResponseItem, Error>)> + Send>>;
+
+pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Error> {
+    if request
+        .dangerous_advanced
+        .as_ref()
+        .and_then(|adv| adv.stream_spawns)
+        == Some(true)
+    {
+        execute_streaming(ctx, request).await
+    } else {
+        execute_detached(request).await
+    }
+}
+
+/// Default mode: re-invoke `objectiveai-cli agents queue deliver` as
+/// a detached subprocess with `stream_spawns = true`, yield the
+/// child's STATUS items (`AgentActive` / `AgentSpawned` — `Value`
+/// spawn output is skipped) up to and including `AllAgentsActive`,
+/// and return.
+/// The subprocess outlives this call — its `tokio::process::Child`
+/// handle is dropped without kill (the SDK's `BinaryExecutor` default
+/// + Windows `DETACHED_PROCESS` flag), so the spawns run to
+/// completion as an orphan.
+async fn execute_detached(request: Request) -> Result<ItemStream, Error> {
+    let mut child_request = request;
+    match child_request.dangerous_advanced.as_mut() {
+        Some(adv) => adv.stream_spawns = Some(true),
+        None => {
+            child_request.dangerous_advanced = Some(RequestDangerousAdvanced {
+                stream_spawns: Some(true),
+            })
+        }
+    }
+
+    let exe = std::env::current_exe()
+        .map_err(|e| Error::Spawn("current_exe".into(), e))?;
+    let executor = BinaryExecutor::from_path(exe).detach(true);
+
+    let mut stream = executor
+        .execute::<Request, ResponseItem>(child_request, None)
+        .await
+        .map_err(|e| Error::Instance(format!(
+            "self-respawn for agents queue deliver: {e}"
+        )))?;
+
+    let out = async_stream::stream! {
+        while let Some(item) = stream.next().await {
+            match item {
+                // Spawn output is the child's business — detached
+                // mode surfaces only the status variants.
+                Ok(ResponseItem::Value(_)) => {}
+                Ok(item) => {
+                    let done = matches!(item, ResponseItem::AllAgentsActive(_));
+                    yield Ok(item);
+                    if done {
+                        // Final item for the detached mode. Dropping
+                        // the stream drops the Child handle without
+                        // kill — the orphan finishes the spawns.
+                        break;
+                    }
+                }
+                Err(e) => yield Err(Error::Instance(format!(
+                    "self-respawn for agents queue deliver: {e}"
+                ))),
+            }
+        }
+    };
+    Ok(Box::pin(out))
+}
+
+/// `stream_spawns = true`: run the full delivery in-process.
+async fn execute_streaming(ctx: &Context, _request: Request) -> Result<ItemStream, Error> {
+    let agents_dir = ctx
+        .filesystem
+        .base_dir()
+        .join("instances")
+        .join("agents");
+    std::fs::create_dir_all(&agents_dir)
+        .map_err(|e| Error::Instance(format!("create agents_dir: {e}")))?;
+
+    // Unique queue-pending AIHs in the caller's subtree, caller
+    // excluded (the query is parent-inclusive; deliver targets only
+    // strict descendants).
+    let caller = ctx.config.agent_instance_hierarchy.clone();
+    let targets = db::message_queue::list_delivery_targets(&ctx.db, &caller).await?;
+    let mut hierarchies: Vec<String> = Vec::new();
+    for target in targets {
+        if target.agent_instance_hierarchy != caller
+            && !hierarchies.contains(&target.agent_instance_hierarchy)
+        {
+            hierarchies.push(target.agent_instance_hierarchy);
+        }
+    }
+
+    let n = hierarchies.len();
+    let mut select_all = futures::stream::SelectAll::new();
+    for (idx, hierarchy) in hierarchies.into_iter().enumerate() {
+        let tagged = deliver_one(ctx.clone(), hierarchy, agents_dir.clone())
+            .map(move |item| (idx, item));
+        select_all.push(Box::pin(tagged) as TaggedStream);
+    }
+
+    let out = async_stream::stream! {
+        if n == 0 {
+            yield Ok(ResponseItem::AllAgentsActive(AllAgentsActive::AllAgentsActive));
+            return;
+        }
+        let mut seen: HashSet<usize> = HashSet::new();
+        let mut merged = select_all;
+        while let Some((idx, item)) = merged.next().await {
+            let first = seen.insert(idx);
+            yield item;
+            // Every per-AIH stream's first item is its resolution —
+            // once all have resolved, every agent is either already
+            // active or freshly spawned. Spawn output keeps flowing
+            // after the marker; only the detached parent stops here.
+            if first && seen.len() == n {
+                yield Ok(ResponseItem::AllAgentsActive(AllAgentsActive::AllAgentsActive));
+            }
+        }
+    };
+    Ok(Box::pin(out))
+}
+
+/// Deliver one AIH. The FIRST item is always the resolution:
+/// `AgentActive` (lock held by a live owner), `AgentSpawned` (lock
+/// won, spawn starting), or a setup `Err` (lock won but no prior
+/// session). On a win, the `LockClaim`'s ownership transfers into
+/// this stream (`_claim`) — released when the stream ends.
+fn deliver_one(
+    ctx: Context,
+    hierarchy: String,
+    agents_dir: std::path::PathBuf,
+) -> impl Stream<Item = Result<ResponseItem, Error>> + Send {
+    async_stream::stream! {
+        let lock_path = agents_dir.join(hierarchy.replace('/', "_"));
+        let Some(claim) = lock_file::try_acquire(&lock_path) else {
+            yield Ok(ResponseItem::AgentActive(AgentActiveResponseItem {
+                r#type: AgentActiveType::AgentActive,
+                agent_instance_hierarchy: hierarchy,
+            }));
+            return;
+        };
+        // Lock ownership lives here for the rest of this stream;
+        // dropping at stream end releases it per-AIH.
+        // `run_multi_pass`'s registry observe of the same hierarchy
+        // is best-effort and silently no-ops on the held lock.
+        let _claim = claim;
+
+        let lookup = match db::logs::lookup_session(&ctx.db, &hierarchy).await {
+            Ok(Some(lookup)) => lookup,
+            Ok(None) => {
+                yield Err(Error::Instance(format!(
+                    "no prior session for {hierarchy:?}"
+                )));
+                return;
+            }
+            Err(e) => {
+                yield Err(e.into());
+                return;
+            }
+        };
+
+        yield Ok(ResponseItem::AgentSpawned(AgentSpawnedResponseItem {
+            r#type: AgentSpawnedType::AgentSpawned,
+            agent_instance_hierarchy: hierarchy.clone(),
+        }));
+
+        // Empty messages: the wake-up turn exists so the agent drains
+        // its own queue (the conduit reads pending rows during the
+        // turn), same shape `run_multi_pass` itself uses on restart.
+        let params = AgentCompletionCreateParams {
+            messages: Vec::new(),
+            provider: None,
+            agent: lookup.agent,
+            response_format: None,
+            seed: None,
+            stream: Some(true),
+            continuation: lookup.continuation,
+        };
+        let inner = crate::command::agents::spawn::run_multi_pass(
+            ctx.clone(),
+            params,
+            None,
+            agents_dir.clone(),
+        );
+        let mut inner = Box::pin(inner);
+        while let Some(item) = inner.next().await {
+            match item {
+                Ok(spawn_item) => {
+                    yield Ok(ResponseItem::Value(ValueResponseItem {
+                        agent_instance_hierarchy: hierarchy.clone(),
+                        value: Box::new(RootResponseItem::Agents(
+                            AgentsResponseItem::Spawn(spawn_item),
+                        )),
+                    }));
+                }
+                Err(e) => yield Err(e),
+            }
+        }
+    }
+}
+
+pub mod request_schema {
+    use objectiveai_sdk::cli::command::agents::queue::deliver as sdk;
+    use objectiveai_sdk::cli::command::agents::queue::deliver::request_schema::{
+        Request, Response,
+    };
+
+    use crate::context::Context;
+    use crate::error::Error;
+
+    pub async fn execute(_ctx: &Context, _request: Request) -> Result<Response, Error> {
+        Ok(objectiveai_sdk::cli::command::ResponseSchema(
+            schemars::schema_for!(sdk::Request),
+        ))
+    }
+}
+
+pub mod response_schema {
+    use objectiveai_sdk::cli::command::agents::queue::deliver as sdk;
+    use objectiveai_sdk::cli::command::agents::queue::deliver::response_schema::{
+        Request, Response,
+    };
+
+    use crate::context::Context;
+    use crate::error::Error;
+
+    pub async fn execute(_ctx: &Context, _request: Request) -> Result<Response, Error> {
+        Ok(objectiveai_sdk::cli::command::ResponseSchema(
+            schemars::schema_for!(sdk::ResponseItem),
+        ))
+    }
+}

--- a/objectiveai-cli/src/command/agents/queue/mod.rs
+++ b/objectiveai-cli/src/command/agents/queue/mod.rs
@@ -14,6 +14,7 @@ use crate::context::Context;
 use crate::error::Error;
 
 pub mod delete;
+pub mod deliver;
 pub mod read;
 
 type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
@@ -37,6 +38,18 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
         Request::DeleteResponseSchema(req) => {
             let value = delete::response_schema::execute(ctx, req).await?;
             once(Ok(ResponseItem::DeleteResponseSchema(value)))
+        }
+        Request::Deliver(req) => {
+            let inner = deliver::execute(ctx, req).await?;
+            Box::pin(inner.map(|r| r.map(ResponseItem::Deliver)))
+        }
+        Request::DeliverRequestSchema(req) => {
+            let value = deliver::request_schema::execute(ctx, req).await?;
+            once(Ok(ResponseItem::DeliverRequestSchema(value)))
+        }
+        Request::DeliverResponseSchema(req) => {
+            let value = deliver::response_schema::execute(ctx, req).await?;
+            once(Ok(ResponseItem::DeliverResponseSchema(value)))
         }
         Request::Read(req) => {
             let inner = read::execute(ctx, req).await?;

--- a/objectiveai-cli/src/command/plugins/run.rs
+++ b/objectiveai-cli/src/command/plugins/run.rs
@@ -14,12 +14,12 @@ use std::pin::Pin;
 use std::process::Stdio;
 use std::sync::Arc;
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use objectiveai_sdk::cli::command::plugins::run::{Request, ResponseItem};
 use objectiveai_sdk::cli::plugins::Output as PluginOutput;
 use objectiveai_sdk::cli::{Error as CliError, ErrorType as CliErrorType};
 use serde::Serialize;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::AsyncWriteExt;
 use tokio::process::{ChildStdin, Command};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -38,14 +38,20 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
         .await
         .ok_or_else(|| Error::PluginNotFound(coord.clone()))?;
 
-    // Config for both the plugin binary and any nested
-    // (plugin-originated) commands it invokes: stamped with this
-    // plugin's coordinate so a nested command's `Context` resolves
-    // `ctx.plugin = Some(PluginPath)` from the threaded env vars.
-    let mut cli_config = ctx.config.clone();
-    cli_config.plugin_owner = Some(request.owner.clone());
-    cli_config.plugin_repository = Some(request.name.clone());
-    cli_config.plugin_version = Some(request.version.clone());
+    // Context for nested (plugin-originated) commands: this caller's
+    // ctx, stamped with the plugin coordinate. `ctx.plugin` is set so
+    // a nested command knows which plugin it runs on behalf of, and
+    // `config.plugin_*` is set so any subprocess that nested command
+    // itself spawns inherits the coordinate via `apply_config_env`.
+    let mut nested_ctx = ctx.clone();
+    nested_ctx.config.plugin_owner = Some(request.owner.clone());
+    nested_ctx.config.plugin_repository = Some(request.name.clone());
+    nested_ctx.config.plugin_version = Some(request.version.clone());
+    nested_ctx.plugin = Some(crate::plugin_path::PluginPath {
+        owner: request.owner.clone(),
+        repository: request.name.clone(),
+        version: request.version.clone(),
+    });
 
     let mut cmd = Command::new(&exe);
     cmd.args(&request.args)
@@ -53,7 +59,7 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    crate::spawn::apply_config_env(&mut cmd, &cli_config);
+    crate::spawn::apply_config_env(&mut cmd, &nested_ctx.config);
 
     let mut child = cmd.spawn().map_err(Error::PluginSpawn)?;
     let stdout = child.stdout.take().expect("stdout was piped");
@@ -94,9 +100,9 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
                             // them on the user-visible `ResponseItem`
                             // stream.
                             let task_id = Some(c.id);
-                            let task = spawn_nested_command(
+                            let task = run_nested_command(
+                                nested_ctx.clone(),
                                 c.command,
-                                cli_config.clone(),
                                 plugin_stdin.clone(),
                                 task_id.clone(),
                             );
@@ -132,11 +138,10 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
             let exit_code = task.await.unwrap_or(-1);
             let envelope = PluginCommandResponse {
                 id: id.as_deref(),
-                value: serde_json::to_value(CommandComplete {
+                value: CommandComplete {
                     kind: "command_complete",
                     exit_code,
-                })
-                .expect("CommandComplete serializes"),
+                },
             };
             let _ = write_envelope(&plugin_stdin, &envelope).await;
         }
@@ -159,61 +164,124 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
     Ok(Box::pin(stream))
 }
 
-/// Whitespace-tokenize `command`, spawn `objectiveai-cli` (the
-/// current binary) with those argv, capture stdout line-by-line, and
-/// write each parsed line back to `plugin_stdin` wrapped in a
-/// [`PluginCommandResponse`] envelope. Returns the nested process's
-/// exit code (used by the outer drain to stamp the terminal
-/// `CommandComplete`).
-///
-/// Tokenization matches legacy: whitespace-only, no shlex.
-fn spawn_nested_command(
+/// Dispatch a plugin-originated command IN-PROCESS — no subprocess, no
+/// Postgres re-bootstrap. Whitespace-tokenize `command` (legacy: no
+/// shlex) and run it through the very same `crate::run` entry the cli
+/// binary uses, against `ctx` (which already carries this caller's
+/// identity plus the plugin coordinate). The body is a mirror of
+/// `main.rs::run_command`: every line that binary would write to stdout
+/// is instead forwarded into `plugin_stdin` wrapped in a
+/// [`PluginCommandResponse`]. Returns an exit code for the terminal
+/// `CommandComplete` (the tool's code on a `ToolExit`, else 0/1).
+fn run_nested_command(
+    ctx: Context,
     command: String,
-    cli_config: crate::run::Config,
     plugin_stdin: Arc<Mutex<ChildStdin>>,
     id: Option<String>,
 ) -> JoinHandle<i32> {
     tokio::spawn(async move {
-        let exe = match std::env::current_exe() {
-            Ok(p) => p,
-            Err(_) => return -1,
-        };
-        let tokens: Vec<String> =
-            command.split_whitespace().map(String::from).collect();
-        let mut cmd = Command::new(&exe);
-        cmd.args(&tokens)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit());
-        crate::spawn::apply_config_env(&mut cmd, &cli_config);
+        let id = id.as_deref();
+        // Whitespace tokenization matches legacy (no shlex).
+        let tokens: Vec<String> = command.split_whitespace().map(String::from).collect();
 
-        let mut child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(_) => return -1,
+        // A plugin may not invoke `plugins` or `tools` commands — no
+        // running another plugin, no running a tool. Forward the same
+        // error line the cli would emit and stop here.
+        let forbidden = match tokens.first().map(String::as_str) {
+            Some("plugins") => Some("plugins"),
+            Some("tools") => Some("tools"),
+            _ => None,
         };
-        let stdout = child.stdout.take().expect("stdout was piped");
-        let mut lines = BufReader::new(stdout).lines();
-        while let Ok(Some(raw)) = lines.next_line().await {
-            let trimmed = raw.trim_end_matches(['\r', '\n']);
-            if trimmed.is_empty() {
-                continue;
+        if let Some(kind) = forbidden {
+            let _ = forward_error(
+                &plugin_stdin,
+                id,
+                &Error::PluginCommandForbidden(kind),
+                Some(true),
+            )
+            .await;
+            return 1;
+        }
+
+        // `args[0]` is the program name, which `crate::run` strips
+        // unconditionally; the plugin's command is just the subcommand
+        // tokens, so prepend a placeholder.
+        let mut args: Vec<String> = vec!["objectiveai-cli".to_string()];
+        args.extend(tokens);
+
+        // A mirror of `main.rs::run_command`: drive the same `crate::run`
+        // stream, but forward each line into the plugin's stdin (wrapped
+        // in a `PluginCommandResponse`) instead of writing it to stdout.
+        let mut stream = match crate::run(args, Some(ctx)).await {
+            Ok(s) => s,
+            Err(e) => {
+                if let Error::ClapParse(ref clap_err) = e {
+                    if crate::is_informational(clap_err) {
+                        let _ = forward_help(&plugin_stdin, id, &clap_err.to_string()).await;
+                        return 0;
+                    }
+                }
+                let _ = forward_error(&plugin_stdin, id, &e, Some(true)).await;
+                return match e {
+                    Error::ToolExit(code) => code,
+                    _ => 1,
+                };
             }
-            let value: serde_json::Value = serde_json::from_str(trimmed)
-                .unwrap_or_else(|_| serde_json::Value::String(trimmed.to_string()));
-            let envelope = PluginCommandResponse {
-                id: id.as_deref(),
-                value,
+        };
+        let mut last_tool_exit: Option<i32> = None;
+        while let Some(item) = stream.next().await {
+            let written = match item {
+                Ok(response) => forward_line(&plugin_stdin, id, &response).await,
+                Err(e) => {
+                    if let Error::ToolExit(code) = &e {
+                        last_tool_exit = Some(*code);
+                    }
+                    forward_error(&plugin_stdin, id, &e, None).await
+                }
             };
-            if write_envelope(&plugin_stdin, &envelope).await.is_err() {
-                // Plugin's stdin is gone — abandon the run.
+            if written.is_err() {
+                // Plugin's stdin is gone; abandon the run.
                 break;
             }
         }
-        match child.wait().await {
-            Ok(s) => s.code().unwrap_or(-1),
-            Err(_) => -1,
-        }
+        last_tool_exit.unwrap_or(0)
     })
+}
+
+/// Mirror of `main.rs::write_line`: serialize `value` and forward it to
+/// the plugin's stdin in a [`PluginCommandResponse`] envelope.
+async fn forward_line<T: Serialize>(
+    plugin_stdin: &Arc<Mutex<ChildStdin>>,
+    id: Option<&str>,
+    value: &T,
+) -> std::io::Result<()> {
+    write_envelope(plugin_stdin, &PluginCommandResponse { id, value }).await
+}
+
+/// Mirror of `main.rs::write_error_line`.
+async fn forward_error(
+    plugin_stdin: &Arc<Mutex<ChildStdin>>,
+    id: Option<&str>,
+    e: &Error,
+    fatal: Option<bool>,
+) -> std::io::Result<()> {
+    let payload = CliError {
+        r#type: CliErrorType::Error,
+        level: Some(objectiveai_sdk::cli::Level::Error),
+        fatal,
+        message: e.output_message(),
+    };
+    forward_line(plugin_stdin, id, &payload).await
+}
+
+/// Mirror of `main.rs::write_help_line`.
+async fn forward_help(
+    plugin_stdin: &Arc<Mutex<ChildStdin>>,
+    id: Option<&str>,
+    help: &str,
+) -> std::io::Result<()> {
+    let payload = serde_json::json!({ "type": "help", "help": help });
+    forward_line(plugin_stdin, id, &payload).await
 }
 
 async fn write_envelope<T: Serialize>(
@@ -233,10 +301,10 @@ async fn write_envelope<T: Serialize>(
 /// locally rather than in the SDK because the SDK's `cli/output`
 /// module that hosts the canonical type is currently torn-up.
 #[derive(Serialize)]
-struct PluginCommandResponse<'a> {
+struct PluginCommandResponse<'a, T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<&'a str>,
-    value: serde_json::Value,
+    value: T,
 }
 
 /// Terminal marker written to plugin stdin after each nested command

--- a/objectiveai-cli/src/command/tasks/list.rs
+++ b/objectiveai-cli/src/command/tasks/list.rs
@@ -9,7 +9,7 @@
 //! Everything else (depth, kind, readiness, offset, count) is
 //! threaded through to `db::tasks::list_schedules_async` as-is.
 
-use objectiveai_sdk::cli::command::tasks::list::{Request, ResponseItem};
+use objectiveai_sdk::cli::command::tasks::list::{Plugin, Request, ResponseItem};
 
 use crate::context::Context;
 use crate::db;
@@ -44,6 +44,12 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<Vec<ResponseItem
             interval: r.interval_seconds.map(|secs| {
                 humantime::format_duration(std::time::Duration::from_secs(secs))
                     .to_string()
+            }),
+            version: r.version as u64,
+            plugin: r.plugin.map(|p| Plugin {
+                owner: p.owner,
+                repository: p.repository,
+                version: p.version,
             }),
         })
         .collect())

--- a/objectiveai-cli/src/command/tasks/list.rs
+++ b/objectiveai-cli/src/command/tasks/list.rs
@@ -1,58 +1,94 @@
-//! `agents tasks list` — read schedules with optional filters.
+//! `agents tasks list` — read schedules for one or more `--target`s.
 //!
-//! Hierarchy scope is resolved at handler time:
-//! - `--agent-instance-hierarchy <h>` → that hierarchy.
-//! - `--tag <name>` → BOUND lookup in `tags.sqlite`; PENDING /
-//!   ABSENT raise structured errors.
-//! - Neither set → cli's own `Config.agent_instance_hierarchy`.
-//!
-//! Everything else (depth, kind, readiness, offset, count) is
-//! threaded through to `db::tasks::list_schedules_async` as-is.
+//! Each target resolves to an AIH (`me` / `instance=…` / `tag=…` —
+//! BOUND-only; GROUPED / ABSENT error) and its matching schedules are
+//! queried concurrently; rows stream out as each target's query lands,
+//! deduped by row id. Kind (`oneshot`/`interval`), readiness
+//! (`pending`/`exhausted`), `after_id`, and `count` filter each query.
 
+use std::collections::HashSet;
+use std::pin::Pin;
+
+use futures::stream::FuturesUnordered;
+use futures::{Stream, StreamExt};
 use objectiveai_sdk::cli::command::tasks::list::{Plugin, Request, ResponseItem};
 
 use crate::context::Context;
-use crate::db;
+use crate::db::tasks::ListedSchedule;
 use crate::error::Error;
 
-pub async fn execute(ctx: &Context, request: Request) -> Result<Vec<ResponseItem>, Error> {
-    let parent =
-        super::resolve_scope(ctx, request.agent_instance_hierarchy, request.tag).await?;
+type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
 
-    let rows = db::tasks::list_schedules(
-        &ctx.db,
-        &parent,
-        request.depth,
-        request.oneshot,
-        request.interval,
-        request.pending,
-        request.exhausted,
-        request.offset.unwrap_or(0),
-        request.count,
-    )
-    .await?;
+pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Error> {
+    let default_parent = ctx.config.agent_instance_hierarchy.clone();
+    let db = ctx.db.clone();
+    let oneshot = request.oneshot;
+    let interval = request.interval;
+    let pending = request.pending;
+    let exhausted = request.exhausted;
+    let after_id = request.after_id;
+    let count = request.count;
+    let stream = async_stream::stream! {
+        // Resolve + query every target concurrently.
+        let mut inflight = FuturesUnordered::new();
+        for target in request.targets {
+            let db = db.clone();
+            let default_parent = default_parent.clone();
+            inflight.push(async move {
+                let aih = super::resolve_target(&db, target, &default_parent).await?;
+                let rows = crate::db::tasks::list_schedules(
+                    &db,
+                    std::slice::from_ref(&aih),
+                    oneshot,
+                    interval,
+                    pending,
+                    exhausted,
+                    after_id,
+                    count,
+                )
+                .await?;
+                Ok::<Vec<ListedSchedule>, Error>(rows)
+            });
+        }
+        // Yield each schedule the moment its target's query lands — never
+        // waiting for the slowest. A `seen` set dedups by row id across
+        // targets that resolve to the same AIH.
+        let mut seen = HashSet::new();
+        while let Some(result) = inflight.next().await {
+            match result {
+                Ok(rows) => {
+                    for r in rows {
+                        if seen.insert(r.id) {
+                            yield Ok(to_response_item(r));
+                        }
+                    }
+                }
+                Err(e) => yield Err(e),
+            }
+        }
+    };
+    Ok(Box::pin(stream))
+}
 
-    Ok(rows
-        .into_iter()
-        .map(|r| ResponseItem {
-            id: format!("{}-{}", r.name, r.id),
-            agent_instance_hierarchy: r.agent_instance_hierarchy,
-            command: r.command,
-            description: r.description,
-            created_at: r.created_at,
-            last_ran_at: r.last_ran_at,
-            interval: r.interval_seconds.map(|secs| {
-                humantime::format_duration(std::time::Duration::from_secs(secs))
-                    .to_string()
-            }),
-            version: r.version as u64,
-            plugin: r.plugin.map(|p| Plugin {
-                owner: p.owner,
-                repository: p.repository,
-                version: p.version,
-            }),
-        })
-        .collect())
+fn to_response_item(r: ListedSchedule) -> ResponseItem {
+    ResponseItem {
+        id: r.id,
+        name: r.name,
+        agent_instance_hierarchy: r.agent_instance_hierarchy,
+        command: r.command,
+        description: r.description,
+        created_at: r.created_at,
+        last_ran_at: r.last_ran_at,
+        interval: r.interval_seconds.map(|secs| {
+            humantime::format_duration(std::time::Duration::from_secs(secs)).to_string()
+        }),
+        version: r.version as u64,
+        plugin: r.plugin.map(|p| Plugin {
+            owner: p.owner,
+            repository: p.repository,
+            version: p.version,
+        }),
+    }
 }
 
 pub mod request_schema {

--- a/objectiveai-cli/src/command/tasks/mod.rs
+++ b/objectiveai-cli/src/command/tasks/mod.rs
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-use futures::{Stream, StreamExt, stream};
+use futures::{Stream, StreamExt};
 use objectiveai_sdk::cli::command::tasks::{Request, ResponseItem};
 
 use crate::context::Context;
@@ -50,6 +50,45 @@ pub(crate) async fn resolve_scope(
     }
 }
 
+/// Resolve one `list` `Target` to the AIH it designates. `Me` → the
+/// cli's own hierarchy; `Direct` → `parent.unwrap_or(default)/leaf`;
+/// `Tag` → BOUND lookup (GROUPED / ABSENT raise structured errors,
+/// same posture as [`resolve_scope`]).
+pub(crate) async fn resolve_target(
+    db: &crate::db::Pool,
+    target: objectiveai_sdk::cli::command::tasks::list::Target,
+    default_parent: &str,
+) -> Result<String, Error> {
+    use crate::db::tags;
+    use objectiveai_sdk::cli::command::tasks::list::Target;
+    match target {
+        Target::Me => Ok(default_parent.to_string()),
+        Target::Direct {
+            parent_agent_instance_hierarchy,
+            agent_instance,
+        } => {
+            let parent = parent_agent_instance_hierarchy
+                .unwrap_or_else(|| default_parent.to_string());
+            Ok(format!("{parent}/{agent_instance}"))
+        }
+        Target::Tag { agent_tag } => match tags::lookup(db, &agent_tag).await? {
+            tags::LookupState::Bound {
+                agent_instance_hierarchy,
+            } => Ok(agent_instance_hierarchy),
+            tags::LookupState::Grouped {
+                tag_group_id,
+                parent_agent_instance_hierarchy,
+                ..
+            } => Err(Error::TagGrouped {
+                tag: agent_tag,
+                tag_group_id,
+                parent_agent_instance_hierarchy,
+            }),
+            tags::LookupState::Absent => Err(Error::TagNotFound(agent_tag)),
+        },
+    }
+}
+
 type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
 
 fn once<T: Send + 'static>(
@@ -73,12 +112,8 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
             once(Ok(ResponseItem::ScheduleResponseSchema(value)))
         }
         Request::List(req) => {
-            // `list::execute` returns the rows up-front; emit one
-            // stream item per row.
-            let items = list::execute(ctx, req).await?;
-            Box::pin(stream::iter(
-                items.into_iter().map(|r| Ok(ResponseItem::List(r))),
-            ))
+            let inner = list::execute(ctx, req).await?;
+            Box::pin(inner.map(|r| r.map(ResponseItem::List)))
         }
         Request::ListRequestSchema(req) => {
             let value = list::request_schema::execute(ctx, req).await?;

--- a/objectiveai-cli/src/command/tasks/mod.rs
+++ b/objectiveai-cli/src/command/tasks/mod.rs
@@ -13,47 +13,9 @@ pub mod list;
 pub mod run;
 pub mod schedule;
 
-/// Resolve the scope `(agent_instance_hierarchy?, tag?)` pair
-/// shared by `list` and `run` into a single hierarchy string.
-/// `tag` resolves BOUND-only — GROUPED / ABSENT raise structured
-/// errors. When neither is given, falls back to the cli's own
-/// `Config.agent_instance_hierarchy`.
-pub(crate) async fn resolve_scope(
-    ctx: &Context,
-    agent_instance_hierarchy: Option<String>,
-    tag: Option<String>,
-) -> Result<String, Error> {
-    match (agent_instance_hierarchy, tag) {
-        (Some(h), None) => Ok(h),
-        (None, Some(tag)) => {
-            use crate::db::tags;
-            match tags::lookup(&ctx.db, &tag).await? {
-                tags::LookupState::Bound { agent_instance_hierarchy } => {
-                    Ok(agent_instance_hierarchy)
-                }
-                tags::LookupState::Grouped {
-                    tag_group_id,
-                    parent_agent_instance_hierarchy,
-                    ..
-                } => Err(Error::TagGrouped {
-                    tag,
-                    tag_group_id,
-                    parent_agent_instance_hierarchy,
-                }),
-                tags::LookupState::Absent => Err(Error::TagNotFound(tag)),
-            }
-        }
-        (None, None) => Ok(ctx.config.agent_instance_hierarchy.clone()),
-        (Some(_), Some(_)) => unreachable!(
-            "clap group `scope` enforces mutex between --agent-instance-hierarchy / --tag"
-        ),
-    }
-}
-
 /// Resolve one `list` `Target` to the AIH it designates. `Me` → the
 /// cli's own hierarchy; `Direct` → `parent.unwrap_or(default)/leaf`;
-/// `Tag` → BOUND lookup (GROUPED / ABSENT raise structured errors,
-/// same posture as [`resolve_scope`]).
+/// `Tag` → BOUND lookup (GROUPED / ABSENT raise structured errors).
 pub(crate) async fn resolve_target(
     db: &crate::db::Pool,
     target: objectiveai_sdk::cli::command::tasks::list::Target,

--- a/objectiveai-cli/src/command/tasks/run.rs
+++ b/objectiveai-cli/src/command/tasks/run.rs
@@ -13,13 +13,21 @@
 //! source schedule's identity (`name` / `aih` / `version` / `plugin`).
 //!
 //! A log-writer listener is spawned at the top of `execute` with an
-//! unbounded receiver; the final stream wrapper sends every yielded
-//! envelope (with its claim's `run_id`, which rides next to the item
-//! internally and never hits the wire) into the channel, and the
-//! listener appends each to `tasks_logs` as it arrives. After the
-//! merge is exhausted the wrapper drops the sender and awaits the
-//! listener so every log line is durably written before the stream
-//! ends.
+//! unbounded receiver; the log wrapper (layer 1, identical in both
+//! modes) sends every envelope (with its claim's `run_id`, which rides
+//! next to the item internally and never hits the wire) into the
+//! channel, and the listener appends each to `tasks_logs` as it
+//! arrives. After the merge is exhausted the wrapper drops the sender
+//! and awaits the listener so every log line is durably written before
+//! the stream ends.
+//!
+//! Output has two modes (layer 2), selected by `request.stream_all`:
+//! `--stream-all` passes every envelope through verbatim
+//! (`ResponseItem::Value`); the default engages the success layer
+//! instead — items are swallowed and each task yields exactly one
+//! `ResponseItem::Success { .., success }` when its stream completes,
+//! `success` being `false` iff the task's final item was an error.
+//! The mode never affects what is logged.
 //!
 //! Each task runs with the schedule's captured identity
 //! (`apply_agent_arguments`) and the plugin that registered it
@@ -33,8 +41,12 @@ use std::pin::Pin;
 
 use futures::{Stream, StreamExt};
 use objectiveai_sdk::cli::command::AgentArguments;
+use std::collections::HashMap;
+
 use objectiveai_sdk::cli::command::ResponseItem as RootResponseItem;
-use objectiveai_sdk::cli::command::tasks::run::{Plugin, Request, ResponseItem};
+use objectiveai_sdk::cli::command::tasks::run::{
+    Plugin, Request, ResponseItem, SuccessResponseItem, ValueResponseItem,
+};
 
 use crate::context::Context;
 use crate::db;
@@ -42,13 +54,21 @@ use crate::error::Error;
 
 type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
 
-/// Internal merge item: each task's stream is tagged with its claim's
-/// `run_id` so the final wrapper can hand every line to the log writer
-/// — the id rides next to the item and never appears on the wire.
-type TaggedStream =
-    Pin<Box<dyn Stream<Item = (i64, Result<ResponseItem, Error>)> + Send>>;
+/// Internal merge event. Items are tagged with their claim's `run_id`
+/// so the log wrapper can hand every line to the log writer — the id
+/// rides next to the item and never appears on the wire. `Done` marks
+/// a task's stream completing (carrying the meta the success layer
+/// needs); `WriterFailed` carries the log-writer finalizer's error
+/// through the layers.
+enum TaskEvent {
+    Item(i64, Result<ResponseItem, Error>),
+    Done(TaskMeta),
+    WriterFailed(Error),
+}
 
-pub async fn execute(ctx: &Context, _request: Request) -> Result<ItemStream, Error> {
+type TaggedStream = Pin<Box<dyn Stream<Item = TaskEvent> + Send>>;
+
+pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Error> {
     // The log-writer listener: spawned up front with an unbounded
     // receiver. It appends each (run_id, line) to `tasks_logs` as they
     // come in, and exits once every sender has dropped.
@@ -95,59 +115,113 @@ pub async fn execute(ctx: &Context, _request: Request) -> Result<ItemStream, Err
     let mut select_all = futures::stream::SelectAll::new();
     for (meta, result) in results {
         let run_id = meta.run_id;
+        // Each task's stream ends with a `Done` marker carrying its
+        // meta, so the success layer can tell when a task completed.
+        let done = meta.clone();
         match result {
             Ok(stream) => {
-                let tagged = stream.map(move |r| {
-                    (
-                        run_id,
-                        r.map(|value| ResponseItem {
-                            agent_instance_hierarchy: meta
-                                .agent_instance_hierarchy
-                                .clone(),
-                            name: meta.name.clone(),
-                            version: meta.version,
-                            plugin: meta.plugin.clone(),
-                            value: Box::new(value),
-                        }),
-                    )
-                });
+                let tagged = stream
+                    .map(move |r| {
+                        TaskEvent::Item(
+                            run_id,
+                            r.map(|value| {
+                                ResponseItem::Value(ValueResponseItem {
+                                    agent_instance_hierarchy: meta
+                                        .agent_instance_hierarchy
+                                        .clone(),
+                                    name: meta.name.clone(),
+                                    version: meta.version,
+                                    plugin: meta.plugin.clone(),
+                                    value: Box::new(value),
+                                })
+                            }),
+                        )
+                    })
+                    .chain(futures::stream::once(async move {
+                        TaskEvent::Done(done)
+                    }));
                 select_all.push(Box::pin(tagged) as TaggedStream);
             }
             Err(e) => {
-                let once: TaggedStream =
-                    Box::pin(futures::stream::once(async move { (run_id, Err(e)) }));
-                select_all.push(once);
+                let tagged = futures::stream::once(async move {
+                    TaskEvent::Item(run_id, Err(e))
+                })
+                .chain(futures::stream::once(async move {
+                    TaskEvent::Done(done)
+                }));
+                select_all.push(Box::pin(tagged) as TaggedStream);
             }
         }
     }
 
-    // The wrapper: forward every merged item to the caller AND send
+    // Layer 1 — the log wrapper, identical regardless of mode: send
     // each Ok envelope (serialized, keyed by its run_id) to the log
-    // writer. Once the merge is exhausted, drop the sender and wait
-    // for the listener to finish draining its queue so every line is
-    // durably in `tasks_logs` before the stream ends.
-    let stream = async_stream::stream! {
+    // writer and pass every event through. Once the merge is
+    // exhausted, drop the sender and wait for the listener to finish
+    // draining its queue so every line is durably in `tasks_logs`
+    // before the stream ends; a writer failure flows on as a trailing
+    // event.
+    let logged: TaggedStream = Box::pin(async_stream::stream! {
         let mut merged = select_all;
-        while let Some((run_id, item)) = merged.next().await {
-            if let Ok(envelope) = &item {
+        while let Some(event) = merged.next().await {
+            if let TaskEvent::Item(run_id, Ok(envelope)) = &event {
                 if let Ok(line) = serde_json::to_string(envelope) {
                     // A dead writer (an earlier insert failed) must
                     // not stop the user-facing stream — its error
                     // surfaces from the join below.
-                    let _ = log_tx.send((run_id, line));
+                    let _ = log_tx.send((*run_id, line));
                 }
             }
-            yield item;
+            yield event;
         }
         drop(log_tx);
         match writer.await {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => yield Err(e),
-            Err(_) => yield Err(Error::WriterPanic),
+            Ok(Err(e)) => yield TaskEvent::WriterFailed(e),
+            Err(_) => yield TaskEvent::WriterFailed(Error::WriterPanic),
         }
+    });
+
+    // Layer 2 — the mode adapter. `--stream-all` skips the success
+    // layer entirely: items pass through verbatim and the Done markers
+    // vanish. The default engages the success layer: items are
+    // swallowed (each run's final-item error-ness tracked) and every
+    // task yields exactly one `{.., success}` summary on its Done.
+    let stream: ItemStream = if request.stream_all {
+        Box::pin(logged.filter_map(|event| async move {
+            match event {
+                TaskEvent::Item(_, item) => Some(item),
+                TaskEvent::Done(_) => None,
+                TaskEvent::WriterFailed(e) => Some(Err(e)),
+            }
+        }))
+    } else {
+        Box::pin(async_stream::stream! {
+            let mut last_err: HashMap<i64, bool> = HashMap::new();
+            let mut inner = logged;
+            while let Some(event) = inner.next().await {
+                match event {
+                    TaskEvent::Item(run_id, item) => {
+                        last_err.insert(run_id, item.is_err());
+                    }
+                    TaskEvent::Done(meta) => {
+                        let success =
+                            !last_err.get(&meta.run_id).copied().unwrap_or(false);
+                        yield Ok(ResponseItem::Success(SuccessResponseItem {
+                            agent_instance_hierarchy: meta.agent_instance_hierarchy,
+                            name: meta.name,
+                            version: meta.version,
+                            plugin: meta.plugin,
+                            success,
+                        }));
+                    }
+                    TaskEvent::WriterFailed(e) => yield Err(e),
+                }
+            }
+        })
     };
 
-    Ok(Box::pin(stream))
+    Ok(stream)
 }
 
 /// Drain the log channel into `tasks_logs` — one INSERT per emitted
@@ -166,8 +240,11 @@ async fn log_writer_loop(
 
 /// Envelope metadata for one fired schedule, cloned out of its
 /// `RunRow` before `run_one` consumes the row, then stamped onto every
-/// item that task emits. `run_id` tags items internally for the log
-/// writer and never appears on the wire envelope.
+/// item that task emits (and onto its terminal `Done` marker, which
+/// the success layer turns into the per-task summary). `run_id` tags
+/// items internally for the log writer and never appears on the wire
+/// envelope.
+#[derive(Clone)]
 struct TaskMeta {
     run_id: i64,
     agent_instance_hierarchy: String,

--- a/objectiveai-cli/src/command/tasks/run.rs
+++ b/objectiveai-cli/src/command/tasks/run.rs
@@ -1,15 +1,25 @@
 //! `agents tasks run` — fire every pending schedule in the caller's
-//! own subtree.
+//! own subtree, recording a run row and a full output log per firing.
 //!
 //! Scope is fixed to the caller's own AIH
 //! (`ctx.config.agent_instance_hierarchy`) plus every descendant.
-//! `db::tasks::collect_and_mark_pending` captures the pending rows
-//! transactionally (bumping `last_ran_at` and deleting fired oneshots
-//! up front), then each row's stored argv is dispatched through the
-//! root `crate::run` — the same entry the binary and `plugins run`'s
-//! nested-command path use — in parallel. Per-task streams are merged
-//! via [`futures::stream::SelectAll`]; each item is wrapped with the
-//! source schedule's `id` so callers can attribute output.
+//! `db::tasks::claim_pending` atomically selects the pending rows AND
+//! inserts their `tasks_runs` rows (advisory-locked, so concurrent
+//! `tasks run` callers never double-fire a schedule); each claimed
+//! row's stored argv is then dispatched through the root `crate::run`
+//! — the same entry the binary and `plugins run`'s nested-command path
+//! use — in parallel. Per-task streams are merged via
+//! [`futures::stream::SelectAll`]; each item is wrapped with the
+//! source schedule's identity (`name` / `aih` / `version` / `plugin`).
+//!
+//! A log-writer listener is spawned at the top of `execute` with an
+//! unbounded receiver; the final stream wrapper sends every yielded
+//! envelope (with its claim's `run_id`, which rides next to the item
+//! internally and never hits the wire) into the channel, and the
+//! listener appends each to `tasks_logs` as it arrives. After the
+//! merge is exhausted the wrapper drops the sender and awaits the
+//! listener so every log line is durably written before the stream
+//! ends.
 //!
 //! Each task runs with the schedule's captured identity
 //! (`apply_agent_arguments`) and the plugin that registered it
@@ -32,13 +42,27 @@ use crate::error::Error;
 
 type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
 
+/// Internal merge item: each task's stream is tagged with its claim's
+/// `run_id` so the final wrapper can hand every line to the log writer
+/// — the id rides next to the item and never appears on the wire.
+type TaggedStream =
+    Pin<Box<dyn Stream<Item = (i64, Result<ResponseItem, Error>)> + Send>>;
+
 pub async fn execute(ctx: &Context, _request: Request) -> Result<ItemStream, Error> {
+    // The log-writer listener: spawned up front with an unbounded
+    // receiver. It appends each (run_id, line) to `tasks_logs` as they
+    // come in, and exits once every sender has dropped.
+    let (log_tx, log_rx) = tokio::sync::mpsc::unbounded_channel::<(i64, String)>();
+    let writer = tokio::spawn(log_writer_loop(ctx.db.clone(), log_rx));
+
     // Scope is the caller's own AIH plus all descendants — no params.
     let parent = ctx.config.agent_instance_hierarchy.clone();
 
-    let rows = db::tasks::collect_and_mark_pending(&ctx.db, &parent).await?;
+    let rows = db::tasks::claim_pending(&ctx.db, &parent).await?;
 
     if rows.is_empty() {
+        // Nothing claimed → nothing to log. `log_tx` drops here and
+        // the writer exits on its own.
         return Ok(Box::pin(futures::stream::empty()));
     }
 
@@ -52,9 +76,10 @@ pub async fn execute(ctx: &Context, _request: Request) -> Result<ItemStream, Err
         let ctx = ctx.clone();
         async move {
             let meta = TaskMeta {
-                id: row.id,
+                run_id: row.run_id,
                 agent_instance_hierarchy: row.agent_instance_hierarchy.clone(),
                 name: row.name.clone(),
+                version: row.version as u64,
                 plugin: row.plugin.clone().map(|p| Plugin {
                     owner: p.owner,
                     repository: p.repository,
@@ -69,37 +94,85 @@ pub async fn execute(ctx: &Context, _request: Request) -> Result<ItemStream, Err
 
     let mut select_all = futures::stream::SelectAll::new();
     for (meta, result) in results {
+        let run_id = meta.run_id;
         match result {
             Ok(stream) => {
                 let tagged = stream.map(move |r| {
-                    r.map(|value| ResponseItem {
-                        id: meta.id,
-                        agent_instance_hierarchy: meta.agent_instance_hierarchy.clone(),
-                        name: meta.name.clone(),
-                        plugin: meta.plugin.clone(),
-                        value: Box::new(value),
-                    })
+                    (
+                        run_id,
+                        r.map(|value| ResponseItem {
+                            agent_instance_hierarchy: meta
+                                .agent_instance_hierarchy
+                                .clone(),
+                            name: meta.name.clone(),
+                            version: meta.version,
+                            plugin: meta.plugin.clone(),
+                            value: Box::new(value),
+                        }),
+                    )
                 });
-                select_all.push(Box::pin(tagged) as ItemStream);
+                select_all.push(Box::pin(tagged) as TaggedStream);
             }
             Err(e) => {
-                let once: ItemStream =
-                    Box::pin(futures::stream::once(async move { Err(e) }));
+                let once: TaggedStream =
+                    Box::pin(futures::stream::once(async move { (run_id, Err(e)) }));
                 select_all.push(once);
             }
         }
     }
 
-    Ok(Box::pin(select_all))
+    // The wrapper: forward every merged item to the caller AND send
+    // each Ok envelope (serialized, keyed by its run_id) to the log
+    // writer. Once the merge is exhausted, drop the sender and wait
+    // for the listener to finish draining its queue so every line is
+    // durably in `tasks_logs` before the stream ends.
+    let stream = async_stream::stream! {
+        let mut merged = select_all;
+        while let Some((run_id, item)) = merged.next().await {
+            if let Ok(envelope) = &item {
+                if let Ok(line) = serde_json::to_string(envelope) {
+                    // A dead writer (an earlier insert failed) must
+                    // not stop the user-facing stream — its error
+                    // surfaces from the join below.
+                    let _ = log_tx.send((run_id, line));
+                }
+            }
+            yield item;
+        }
+        drop(log_tx);
+        match writer.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => yield Err(e),
+            Err(_) => yield Err(Error::WriterPanic),
+        }
+    };
+
+    Ok(Box::pin(stream))
+}
+
+/// Drain the log channel into `tasks_logs` — one INSERT per emitted
+/// item, written as they come in. Returns once every sender has
+/// dropped and the queue is empty; a failed INSERT exits early and the
+/// error surfaces as the run stream's trailing item.
+async fn log_writer_loop(
+    pool: crate::db::Pool,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<(i64, String)>,
+) -> Result<(), Error> {
+    while let Some((run_id, value)) = rx.recv().await {
+        db::tasks::insert_task_log(&pool, run_id, &value).await?;
+    }
+    Ok(())
 }
 
 /// Envelope metadata for one fired schedule, cloned out of its
 /// `RunRow` before `run_one` consumes the row, then stamped onto every
-/// item that task emits.
+/// item that task emits. `run_id` tags items internally for the log
+/// writer and never appears on the wire envelope.
 struct TaskMeta {
-    id: i64,
+    run_id: i64,
     agent_instance_hierarchy: String,
     name: String,
+    version: u64,
     plugin: Option<Plugin>,
 }
 

--- a/objectiveai-cli/src/command/tasks/run.rs
+++ b/objectiveai-cli/src/command/tasks/run.rs
@@ -1,37 +1,30 @@
-//! `agents tasks run` — fire every pending schedule in scope.
+//! `agents tasks run` — fire every pending schedule in the caller's
+//! own subtree.
 //!
-//! Resolves the scope (literal hierarchy / tag lookup / default
-//! to `ctx.config.agent_instance_hierarchy`), captures every
-//! pending row via the transactional
-//! `db::tasks::collect_and_mark_pending_async` (which also bumps
-//! `last_ran_at` and deletes oneshots upfront), then dispatches
-//! each row's stored argv through the in-process root command
-//! dispatcher in parallel. Per-task streams are merged via
-//! [`futures::stream::SelectAll`]; each item is wrapped with the
-//! source schedule's `name` so callers can attribute output.
+//! Scope is fixed to the caller's own AIH
+//! (`ctx.config.agent_instance_hierarchy`) plus every descendant.
+//! `db::tasks::collect_and_mark_pending` captures the pending rows
+//! transactionally (bumping `last_ran_at` and deleting fired oneshots
+//! up front), then each row's stored argv is dispatched through the
+//! root `crate::run` — the same entry the binary and `plugins run`'s
+//! nested-command path use — in parallel. Per-task streams are merged
+//! via [`futures::stream::SelectAll`]; each item is wrapped with the
+//! source schedule's `id` so callers can attribute output.
 //!
-//! Why we don't use `CliCommandExecutor`'s generic
-//! `execute<R, T>`: the trait method's hidden async type goes
-//! through `crate::command::command::execute`, which dispatches
-//! back to leaves (including this one), creating a type-inference
-//! cycle. We inline what the executor does — `parse_request` +
-//! per-task ctx override + `command::command::execute` — so the
-//! recursion lives in runtime control flow, not type inference.
-//! And because we already have the typed root `ResponseItem` out
-//! of the local dispatcher, we skip the serde_json round-trip
-//! that the generic `execute<_, T>` uses to land on `T`.
+//! Each task runs with the schedule's captured identity
+//! (`apply_agent_arguments`) and the plugin that registered it
+//! (`apply_plugin`) re-installed on the run ctx — both
+//! `config.plugin_*` and `ctx.plugin`.
 //!
-//! Pre-stream `Err`s (e.g. the scheduled command failed to
-//! parse) are re-emitted as a single-item error stream in the
-//! merged output, matching the deliver leaf's pattern.
+//! Pre-stream `Err`s (e.g. the scheduled command failed to parse) are
+//! re-emitted as a single-item error stream in the merged output.
 
 use std::pin::Pin;
 
 use futures::{Stream, StreamExt};
 use objectiveai_sdk::cli::command::AgentArguments;
 use objectiveai_sdk::cli::command::ResponseItem as RootResponseItem;
-use objectiveai_sdk::cli::command::tasks::run::{Request, ResponseItem};
-use objectiveai_sdk::cli::command::parse_request;
+use objectiveai_sdk::cli::command::tasks::run::{Plugin, Request, ResponseItem};
 
 use crate::context::Context;
 use crate::db;
@@ -39,43 +32,51 @@ use crate::error::Error;
 
 type ItemStream = Pin<Box<dyn Stream<Item = Result<ResponseItem, Error>> + Send>>;
 
-pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Error> {
-    let parent = super::resolve_scope(ctx, request.agent_instance_hierarchy, request.tag).await?;
+pub async fn execute(ctx: &Context, _request: Request) -> Result<ItemStream, Error> {
+    // Scope is the caller's own AIH plus all descendants — no params.
+    let parent = ctx.config.agent_instance_hierarchy.clone();
 
-    let rows = db::tasks::collect_and_mark_pending(
-        &ctx.db,
-        &parent,
-        request.depth,
-    )
-    .await?;
+    let rows = db::tasks::collect_and_mark_pending(&ctx.db, &parent).await?;
 
     if rows.is_empty() {
         return Ok(Box::pin(futures::stream::empty()));
     }
 
     // Kick all per-task dispatches off in parallel. Each future
-    // resolves to `(id, Result<RootStream, Error>)` where `id` is
-    // the wire-shape `"{name}-{db_id}"` — pre-stream errors
-    // (parse / handler-rejection) are folded into the merged
-    // stream as one-item error streams below.
+    // resolves to `(TaskMeta, Result<RootStream, Error>)` — the meta
+    // is cloned out of the `RunRow` before `run_one` consumes it, and
+    // tags every emitted item below. Pre-stream errors (parse /
+    // handler-rejection) are folded into the merged stream as one-item
+    // error streams.
     let starts = rows.into_iter().map(|row| {
         let ctx = ctx.clone();
         async move {
-            let id = format!("{}-{}", row.name, row.id);
-            let stream_result = run_one(&ctx, row.command, &row.agent_arguments).await;
-            (id, stream_result)
+            let meta = TaskMeta {
+                id: row.id,
+                agent_instance_hierarchy: row.agent_instance_hierarchy.clone(),
+                name: row.name.clone(),
+                plugin: row.plugin.clone().map(|p| Plugin {
+                    owner: p.owner,
+                    repository: p.repository,
+                    version: p.version,
+                }),
+            };
+            let stream_result = run_one(&ctx, row).await;
+            (meta, stream_result)
         }
     });
     let results = futures::future::join_all(starts).await;
 
     let mut select_all = futures::stream::SelectAll::new();
-    for (id, result) in results {
+    for (meta, result) in results {
         match result {
             Ok(stream) => {
-                let tag = id;
                 let tagged = stream.map(move |r| {
                     r.map(|value| ResponseItem {
-                        id: tag.clone(),
+                        id: meta.id,
+                        agent_instance_hierarchy: meta.agent_instance_hierarchy.clone(),
+                        name: meta.name.clone(),
+                        plugin: meta.plugin.clone(),
                         value: Box::new(value),
                     })
                 });
@@ -92,6 +93,16 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
     Ok(Box::pin(select_all))
 }
 
+/// Envelope metadata for one fired schedule, cloned out of its
+/// `RunRow` before `run_one` consumes the row, then stamped onto every
+/// item that task emits.
+struct TaskMeta {
+    id: i64,
+    agent_instance_hierarchy: String,
+    name: String,
+    plugin: Option<Plugin>,
+}
+
 /// Per-task stream — yields the typed root `ResponseItem` that
 /// `crate::command::command::execute` already produces. No JSON
 /// round-trip: the executor's `to_value` + `extract_leaf` dance
@@ -100,21 +111,18 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<ItemStream, Erro
 /// typed end-to-end.
 type RootStream = Pin<Box<dyn Stream<Item = Result<RootResponseItem, Error>> + Send>>;
 
-/// Dispatch one stored schedule. Mirrors
-/// `CliCommandExecutor::execute<_, RootResponseItem>` with the
-/// serde round-trip dropped — see [`RootStream`].
-async fn run_one(
-    ctx: &Context,
-    argv: Vec<String>,
-    agent_arguments: &AgentArguments,
-) -> Result<RootStream, Error> {
-    let sdk_request = parse_request(&argv).map_err(|e| match e {
-        objectiveai_sdk::cli::command::ParseError::Clap(e) => Error::ClapParse(e),
-        objectiveai_sdk::cli::command::ParseError::FromArgs(e) => Error::FromArgs(e),
-    })?;
-    let task_ctx = apply_agent_arguments(ctx, agent_arguments);
-    let stream = crate::command::command::execute(&task_ctx, sdk_request).await?;
-    Ok(Box::pin(stream))
+/// Dispatch one stored schedule through the root `crate::run` — the
+/// same entry `main.rs` and `plugins run`'s nested-command path use —
+/// against a ctx carrying the schedule's captured identity and the
+/// plugin that registered it. `crate::run` parses the argv itself, so
+/// we prepend a placeholder program name (it strips `argv[0]`).
+async fn run_one(ctx: &Context, row: db::tasks::RunRow) -> Result<RootStream, Error> {
+    let mut task_ctx = apply_agent_arguments(ctx, &row.agent_arguments);
+    apply_plugin(&mut task_ctx, row.plugin);
+
+    let mut args = vec!["objectiveai-cli".to_string()];
+    args.extend(row.command);
+    crate::run(args, Some(task_ctx)).await
 }
 
 /// Clone `ctx` and overwrite the seven identity fields on its
@@ -135,6 +143,28 @@ fn apply_agent_arguments(ctx: &Context, args: &AgentArguments) -> Context {
     ctx.config.response_ids = args.response_ids.clone();
     ctx.config.mcp_session_id = args.mcp_session_id.clone();
     ctx
+}
+
+/// Re-install the schedule's registering plugin (if any) on the run
+/// ctx — both `config.plugin_*` (so any subprocess the task spawns
+/// inherits it via `apply_config_env`) and `ctx.plugin`. `None`
+/// overrides whatever plugin the *caller* was running under, so a task
+/// scheduled by a non-plugin never inherits one.
+fn apply_plugin(ctx: &mut Context, plugin: Option<crate::plugin_path::PluginPath>) {
+    match plugin {
+        Some(p) => {
+            ctx.config.plugin_owner = Some(p.owner.clone());
+            ctx.config.plugin_repository = Some(p.repository.clone());
+            ctx.config.plugin_version = Some(p.version.clone());
+            ctx.plugin = Some(p);
+        }
+        None => {
+            ctx.config.plugin_owner = None;
+            ctx.config.plugin_repository = None;
+            ctx.config.plugin_version = None;
+            ctx.plugin = None;
+        }
+    }
 }
 
 pub mod request_schema {

--- a/objectiveai-cli/src/command/tasks/schedule.rs
+++ b/objectiveai-cli/src/command/tasks/schedule.rs
@@ -34,8 +34,14 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<Response, Error>
         &ctx.config.agent_instance_hierarchy,
         request.interval_seconds,
         &agent_arguments,
+        ctx.plugin.as_ref(),
+        request.overwrite,
     )
-    .await?;
+    .await?
+    .ok_or_else(|| Error::ScheduleAlreadyExists {
+        name: name.clone(),
+        agent_instance_hierarchy: ctx.config.agent_instance_hierarchy.clone(),
+    })?;
 
     Ok(Response { id: format!("{name}-{db_id}") })
 }

--- a/objectiveai-cli/src/command/tasks/schedule.rs
+++ b/objectiveai-cli/src/command/tasks/schedule.rs
@@ -26,7 +26,7 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<Response, Error>
     };
 
     let name = request.name.clone();
-    let db_id = db::tasks::insert_schedule(
+    let (_db_id, version) = db::tasks::insert_schedule(
         &ctx.db,
         &request.name,
         &request.command,
@@ -43,7 +43,11 @@ pub async fn execute(ctx: &Context, request: Request) -> Result<Response, Error>
         agent_instance_hierarchy: ctx.config.agent_instance_hierarchy.clone(),
     })?;
 
-    Ok(Response { id: format!("{name}-{db_id}") })
+    Ok(Response {
+        name,
+        agent_instance_hierarchy: ctx.config.agent_instance_hierarchy.clone(),
+        version: version as u64,
+    })
 }
 
 pub mod request_schema {

--- a/objectiveai-cli/src/db/init.rs
+++ b/objectiveai-cli/src/db/init.rs
@@ -189,15 +189,33 @@ CREATE TABLE IF NOT EXISTS message_queue_files (
 
 CREATE TABLE IF NOT EXISTS schedules (
     id                       BIGSERIAL PRIMARY KEY,
-    name                     TEXT   NOT NULL UNIQUE,
+    name                     TEXT   NOT NULL,
     command                  TEXT   NOT NULL,
     description              TEXT   NOT NULL,
     agent_instance_hierarchy TEXT   NOT NULL,
     interval_seconds         BIGINT
         CHECK (interval_seconds IS NULL OR interval_seconds >= 0),
     agent_arguments          TEXT   NOT NULL,
+    -- Overwrite count: 1 on first insert, incremented each time
+    -- `tasks schedule --overwrite` replaces this (name, aih) row.
+    version                  BIGINT NOT NULL DEFAULT 1,
+    -- Plugin coordinate of the plugin that registered this schedule,
+    -- captured from `ctx.plugin` at schedule time. All three NULL when
+    -- not scheduled by a plugin; all three set when it was (enforced by
+    -- the CHECK below).
+    plugin_owner             TEXT,
+    plugin_repository        TEXT,
+    plugin_version           TEXT,
     created_at               BIGINT NOT NULL,
-    last_ran_at              BIGINT
+    last_ran_at              BIGINT,
+    -- A schedule name is unique per agent instance hierarchy, not
+    -- globally — two different agents may reuse the same name.
+    UNIQUE (name, agent_instance_hierarchy),
+    CHECK (
+        (plugin_owner IS NULL AND plugin_repository IS NULL AND plugin_version IS NULL)
+        OR
+        (plugin_owner IS NOT NULL AND plugin_repository IS NOT NULL AND plugin_version IS NOT NULL)
+    )
 );
 
 -- AFTER-UPDATE trigger on `message_queue.active`: every soft-flip

--- a/objectiveai-cli/src/db/init.rs
+++ b/objectiveai-cli/src/db/init.rs
@@ -196,8 +196,11 @@ CREATE TABLE IF NOT EXISTS schedules (
     interval_seconds         BIGINT
         CHECK (interval_seconds IS NULL OR interval_seconds >= 0),
     agent_arguments          TEXT   NOT NULL,
-    -- Overwrite count: 1 on first insert, incremented each time
-    -- `tasks schedule --overwrite` replaces this (name, aih) row.
+    -- Versions are separate rows: `tasks schedule --overwrite` INSERTS
+    -- a new row with version = max+1 that shadows the older versions
+    -- of the same (name, aih). Shadowed rows never run again and never
+    -- list, but stay on disk so `tasks_runs` history is per-version.
+    -- Rows are NEVER deleted.
     version                  BIGINT NOT NULL DEFAULT 1,
     -- Plugin coordinate of the plugin that registered this schedule,
     -- captured from `ctx.plugin` at schedule time. All three NULL when
@@ -207,16 +210,39 @@ CREATE TABLE IF NOT EXISTS schedules (
     plugin_repository        TEXT,
     plugin_version           TEXT,
     created_at               BIGINT NOT NULL,
-    last_ran_at              BIGINT,
-    -- A schedule name is unique per agent instance hierarchy, not
-    -- globally — two different agents may reuse the same name.
-    UNIQUE (name, agent_instance_hierarchy),
+    -- A schedule name is unique per agent instance hierarchy and
+    -- version — two different agents may reuse the same name, and one
+    -- agent's schedule keeps every version it ever had as rows.
+    UNIQUE (name, agent_instance_hierarchy, version),
     CHECK (
         (plugin_owner IS NULL AND plugin_repository IS NULL AND plugin_version IS NULL)
         OR
         (plugin_owner IS NOT NULL AND plugin_repository IS NOT NULL AND plugin_version IS NOT NULL)
     )
 );
+
+-- One row per schedule firing. A oneshot is exhausted the moment it
+-- has a run; a recurring row's readiness keys off its newest run.
+-- Written atomically by the same claim query that selects the tasks
+-- `tasks run` fires, so concurrent runners never double-claim.
+CREATE TABLE IF NOT EXISTS tasks_runs (
+    id          BIGSERIAL PRIMARY KEY,
+    schedule_id BIGINT NOT NULL REFERENCES schedules(id),
+    ran_at      BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS tasks_runs_schedule_idx
+    ON tasks_runs(schedule_id, ran_at DESC);
+
+-- One row per item a fired task emitted on `tasks run`'s stream,
+-- serialized exactly as the wire envelope, linked to its run.
+CREATE TABLE IF NOT EXISTS tasks_logs (
+    id         BIGSERIAL PRIMARY KEY,
+    run_id     BIGINT NOT NULL REFERENCES tasks_runs(id),
+    value      TEXT   NOT NULL,
+    created_at BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS tasks_logs_run_idx
+    ON tasks_logs(run_id, id);
 
 -- AFTER-UPDATE trigger on `message_queue.active`: every soft-flip
 -- (TRUE → FALSE) emits a `NOTIFY message_queue_inactive '<id>'`

--- a/objectiveai-cli/src/db/logs/read_all.rs
+++ b/objectiveai-cli/src/db/logs/read_all.rs
@@ -451,7 +451,7 @@ pub async fn read_all_for_hierarchy(
          WHERE m.agent_instance_hierarchy = $1 \
            AND m.\"index\" > COALESCE($2, 0) \
          ORDER BY m.\"index\" ASC \
-         LIMIT COALESCE($3, 1000)",
+         LIMIT $3",
         select = SELECT_SHAPE,
         from = FROM_JOINS,
     );
@@ -498,7 +498,7 @@ pub async fn read_pending_for_parent(
              WHERE q.parent_agent_instance_hierarchy = $1 \
                AND m.\"index\" > GREATEST(q.read_index, COALESCE($2, 0)) \
              ORDER BY m.\"index\" ASC \
-             LIMIT COALESCE($3, 1000) \
+             LIMIT $3 \
          ), \
          maxes AS ( \
              SELECT agent_instance_hierarchy AS spawned, MAX(id) AS max_id \

--- a/objectiveai-cli/src/db/message_queue.rs
+++ b/objectiveai-cli/src/db/message_queue.rs
@@ -457,7 +457,7 @@ pub async fn list_pending_for_targets(
            ) \
            AND c.id > COALESCE($3, 0) \
          ORDER BY p.id ASC, c.id ASC \
-         LIMIT COALESCE($4, 1000)",
+         LIMIT $4",
     )
     .bind(if hier_targets.is_empty() { None } else { Some(&hier_targets) })
     .bind(if tag_targets.is_empty() { None } else { Some(&tag_targets) })

--- a/objectiveai-cli/src/db/tasks.rs
+++ b/objectiveai-cli/src/db/tasks.rs
@@ -8,7 +8,6 @@
 
 use objectiveai_sdk::cli::command::AgentArguments;
 use sqlx::Row as _;
-use sqlx::error::DatabaseError as _;
 
 use super::{Error, Pool};
 
@@ -151,23 +150,20 @@ pub async fn insert_schedule(
 ///   unlimited via `LIMIT NULL`; we pass NULL explicitly).
 pub async fn list_schedules(
     pool: &Pool,
-    parent: &str,
-    max_depth: Option<u64>,
+    hierarchies: &[String],
     oneshot_only: bool,
     interval_only: bool,
     pending_only: bool,
     exhausted_only: bool,
-    offset: u64,
+    after_id: Option<i64>,
     count: Option<u64>,
 ) -> Result<Vec<ListedSchedule>, Error> {
-    let max_depth_param: Option<i64> = max_depth.map(|d| d as i64);
     let count_param: Option<i64> = count.map(|c| c as i64);
-    let offset_param: i64 = offset as i64;
 
-    // Positional binds in the same order as `$1..$9`. The SQL mirrors
-    // the sqlite predecessor's named_params version 1:1 modulo
-    // postgres dialect (`length(replace(x, '/', ''))` works identically;
-    // the `($N IS NULL OR …)` short-circuits are postgres-native).
+    // Exact-AIH scope (`= ANY($1)`, no subtree descent), the kind /
+    // readiness short-circuits (`($N = 0 OR …)`, $5 = now), and keyset
+    // pagination forward by ascending id (`id > COALESCE($7, 0)`).
+    // `LIMIT $8` is `NULL` when `count` is `None` → unlimited.
     let rows = sqlx::query(
         "SELECT id, \
                 name, \
@@ -182,52 +178,35 @@ pub async fn list_schedules(
                 plugin_version, \
                 version \
          FROM schedules \
-         WHERE \
-             /* Hierarchy + depth filter. Inclusive of parent itself. */ \
-             ( \
-                 agent_instance_hierarchy = $1 \
-                 OR ( \
-                     agent_instance_hierarchy LIKE ($1 || '/%') \
-                     AND ( \
-                         $2::bigint IS NULL \
-                         OR \
-                         ( \
-                             (length(agent_instance_hierarchy) \
-                              - length(replace(agent_instance_hierarchy, '/', ''))) \
-                             - (length($1) \
-                                - length(replace($1, '/', ''))) \
-                         ) <= $2 \
-                     ) \
-                 ) \
-             ) \
-             AND ($3 = 0 OR interval_seconds IS NULL) \
-             AND ($4 = 0 OR interval_seconds IS NOT NULL) \
-             AND ($5 = 0 OR ( \
+         WHERE agent_instance_hierarchy = ANY($1) \
+             AND ($2 = 0 OR interval_seconds IS NULL) \
+             AND ($3 = 0 OR interval_seconds IS NOT NULL) \
+             AND ($4 = 0 OR ( \
                  (interval_seconds IS NULL AND last_ran_at IS NULL) \
                  OR \
                  (interval_seconds IS NOT NULL \
                   AND (last_ran_at IS NULL \
-                       OR ($6 - last_ran_at) >= interval_seconds)) \
+                       OR ($5 - last_ran_at) >= interval_seconds)) \
              )) \
-             AND ($7 = 0 OR ( \
+             AND ($6 = 0 OR ( \
                  (interval_seconds IS NULL AND last_ran_at IS NOT NULL) \
                  OR \
                  (interval_seconds IS NOT NULL \
                   AND last_ran_at IS NOT NULL \
-                  AND ($6 - last_ran_at) < interval_seconds) \
+                  AND ($5 - last_ran_at) < interval_seconds) \
              )) \
+             AND id > COALESCE($7, 0) \
          ORDER BY id ASC \
-         LIMIT $8 OFFSET $9",
+         LIMIT $8",
     )
-    .bind(parent)
-    .bind(max_depth_param)
+    .bind(hierarchies)
     .bind(oneshot_only as i64)
     .bind(interval_only as i64)
     .bind(pending_only as i64)
     .bind(now_seconds())
     .bind(exhausted_only as i64)
+    .bind(after_id)
     .bind(count_param)
-    .bind(offset_param)
     .fetch_all(&**pool)
     .await?;
 

--- a/objectiveai-cli/src/db/tasks.rs
+++ b/objectiveai-cli/src/db/tasks.rs
@@ -1,15 +1,36 @@
-//! `schedules` table + the `agents tasks {schedule, list, run}` storage
-//! tier.
+//! `schedules` + `tasks_runs` + `tasks_logs` — the `agents tasks
+//! {schedule, list, run}` storage tier.
 //!
-//! Per-row payload: an argv vector to invoke on each scheduled poll,
-//! the minimum interval between invocations in seconds, and a JSON
-//! snapshot of the caller's `AgentArguments` so the runner can
+//! Per-schedule payload: an argv vector to invoke on each scheduled
+//! poll, the minimum interval between invocations in seconds, and a
+//! JSON snapshot of the caller's `AgentArguments` so the runner can
 //! re-install identity env vars at fire-time.
+//!
+//! Schedule rows are NEVER deleted. Versions are separate rows (`--
+//! overwrite` inserts `version = max+1`, shadowing the older rows);
+//! run history is one `tasks_runs` row per firing (written atomically
+//! by [`claim_pending`]'s claim query); each item a fired task emits
+//! is one `tasks_logs` row linked to its run.
 
 use objectiveai_sdk::cli::command::AgentArguments;
 use sqlx::Row as _;
 
 use super::{Error, Pool};
+
+/// Serializes every [`claim_pending`] claim transaction via
+/// `pg_advisory_xact_lock` — readiness reads `tasks_runs` while a
+/// concurrent claimer's inserts aren't yet visible, so row locks alone
+/// can't prevent a double-claim.
+const CLAIM_LOCK_KEY: i64 = 0x7461_736b_735f_7275; // "tasks_ru"
+
+/// SQL predicate: this `schedules` row (aliased `s`) is the newest
+/// version of its `(name, agent_instance_hierarchy)` — older versions
+/// are shadowed: never listed, never run.
+const LATEST_VERSION_PREDICATE: &str = "s.version = ( \
+    SELECT MAX(s2.version) FROM schedules s2 \
+    WHERE s2.name = s.name \
+      AND s2.agent_instance_hierarchy = s.agent_instance_hierarchy \
+)";
 
 /// One row from `schedules` as surfaced by `agents tasks list`.
 /// `command` is decoded from its JSON-string column.
@@ -21,10 +42,12 @@ pub struct ListedSchedule {
     pub command: Vec<String>,
     pub description: String,
     pub created_at: i64,
+    /// Unix seconds of this row's newest `tasks_runs` entry — derived,
+    /// not a column.
     pub last_ran_at: Option<i64>,
     pub interval_seconds: Option<u64>,
-    /// Overwrite count: `1` on first insert, incremented on each
-    /// `--overwrite` replacement of this `(name, aih)` row.
+    /// Version of this row: `1` on first insert, `max+1` per
+    /// `--overwrite`. Only the newest version of a `(name, aih)` lists.
     pub version: i64,
     /// The plugin that registered this schedule, if any. `Some` iff all
     /// three `plugin_*` columns are set (the table CHECK enforces it).
@@ -32,14 +55,14 @@ pub struct ListedSchedule {
 }
 
 /// Subset of a schedule row that `agents tasks run` needs to fire one
-/// task. Each row here has already had its `last_ran_at` bumped to
-/// `now`, and (if it was a oneshot) been deleted, inside the same
-/// transaction.
+/// task, plus the id of the `tasks_runs` row the claim minted for this
+/// firing (the log writer links every emitted item to it).
 #[derive(Debug, Clone)]
 pub struct RunRow {
-    pub id: i64,
+    pub run_id: i64,
     pub name: String,
     pub agent_instance_hierarchy: String,
+    pub version: i64,
     pub command: Vec<String>,
     pub agent_arguments: AgentArguments,
     /// The plugin that registered this schedule, if any — re-installed
@@ -55,19 +78,23 @@ fn now_seconds() -> i64 {
         .unwrap_or(0)
 }
 
-/// Insert one schedule row and return its auto-incremented id.
+/// Insert one schedule row and return its `(id, version)`.
 ///
 /// `command` is JSON-serialised as a string array (the argv shape the
 /// runner will exec). `agent_arguments` is JSON-serialised verbatim —
 /// the runner re-installs each `Some(_)` field as the matching env var
 /// when the schedule fires.
 ///
-/// `(name, agent_instance_hierarchy)` is unique. When `overwrite` is
-/// false a collision yields `Ok(None)` so the caller can raise a
-/// friendly "already exists" error; when true the existing row is
-/// replaced in place and its `version` bumped (`last_ran_at` reset so
-/// the redefined schedule fires fresh). A brand-new row starts at
-/// `version = 1`.
+/// Versions are separate rows, unique on `(name, aih, version)`:
+/// * `overwrite = false` inserts `version = 1`; if the schedule was
+///   ever created, version 1 already exists and the unique violation
+///   yields `Ok(None)` so the caller can raise a friendly "already
+///   exists" error.
+/// * `overwrite = true` inserts a NEW row with `version = max + 1`,
+///   shadowing the older rows (they never list or run again, but stay
+///   for per-version run history). The fresh row has no `tasks_runs`
+///   entries, so it is immediately pending. A concurrent overwrite can
+///   collide on the computed version; retry a bounded number of times.
 pub async fn insert_schedule(
     pool: &Pool,
     name: &str,
@@ -78,7 +105,7 @@ pub async fn insert_schedule(
     agent_arguments: &AgentArguments,
     plugin: Option<&crate::plugin_path::PluginPath>,
     overwrite: bool,
-) -> Result<Option<i64>, Error> {
+) -> Result<Option<(i64, i64)>, Error> {
     let command_json = serde_json::to_string(command)?;
     let agent_arguments_json = serde_json::to_string(agent_arguments)?;
     let interval_param: Option<i64> = interval_seconds.map(|s| s as i64);
@@ -91,67 +118,80 @@ pub async fn insert_schedule(
         None => (None, None, None),
     };
 
-    // `version` is omitted from the column list so the table's
-    // `DEFAULT 1` applies on a fresh insert; the overwrite path bumps
-    // it explicitly off the existing row.
     let columns = "(name, command, description, agent_instance_hierarchy, interval_seconds, \
-                    agent_arguments, plugin_owner, plugin_repository, plugin_version, created_at)";
-    let values = "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
-
-    let query = if overwrite {
-        format!(
-            "INSERT INTO schedules {columns} {values} \
-             ON CONFLICT (name, agent_instance_hierarchy) DO UPDATE SET \
-                 command = EXCLUDED.command, \
-                 description = EXCLUDED.description, \
-                 interval_seconds = EXCLUDED.interval_seconds, \
-                 agent_arguments = EXCLUDED.agent_arguments, \
-                 plugin_owner = EXCLUDED.plugin_owner, \
-                 plugin_repository = EXCLUDED.plugin_repository, \
-                 plugin_version = EXCLUDED.plugin_version, \
-                 last_ran_at = NULL, \
-                 version = schedules.version + 1 \
-             RETURNING id"
-        )
+                    agent_arguments, plugin_owner, plugin_repository, plugin_version, created_at, \
+                    version)";
+    // Non-overwrite always claims version 1 — colliding with it means
+    // the schedule already exists (rows are never deleted). Overwrite
+    // computes max+1 in the INSERT itself.
+    let version_expr = if overwrite {
+        "(SELECT COALESCE(MAX(version), 0) + 1 FROM schedules \
+          WHERE name = $1 AND agent_instance_hierarchy = $4)"
     } else {
-        format!("INSERT INTO schedules {columns} {values} RETURNING id")
+        "1"
     };
+    let query = format!(
+        "INSERT INTO schedules {columns} \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, {version_expr}) \
+         RETURNING id, version"
+    );
 
-    let result = sqlx::query_scalar::<_, i64>(&query)
-        .bind(name)
-        .bind(command_json)
-        .bind(description)
-        .bind(agent_instance_hierarchy)
-        .bind(interval_param)
-        .bind(agent_arguments_json)
-        .bind(plugin_owner)
-        .bind(plugin_repository)
-        .bind(plugin_version)
-        .bind(now_seconds())
-        .fetch_one(&**pool)
-        .await;
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        let result = sqlx::query_as::<_, (i64, i64)>(&query)
+            .bind(name)
+            .bind(&command_json)
+            .bind(description)
+            .bind(agent_instance_hierarchy)
+            .bind(interval_param)
+            .bind(&agent_arguments_json)
+            .bind(plugin_owner)
+            .bind(plugin_repository)
+            .bind(plugin_version)
+            .bind(now_seconds())
+            .fetch_one(&**pool)
+            .await;
 
-    match result {
-        Ok(id) => Ok(Some(id)),
-        // Non-overwrite collision on the (name, aih) unique constraint:
-        // report absence so the handler can surface a clean error.
-        Err(sqlx::Error::Database(e)) if e.is_unique_violation() => Ok(None),
-        Err(e) => Err(e.into()),
+        return match result {
+            Ok(pair) => Ok(Some(pair)),
+            Err(sqlx::Error::Database(e)) if e.is_unique_violation() => {
+                if overwrite {
+                    if attempts < 3 {
+                        // Concurrent overwrite computed the same max+1
+                        // — re-run; MAX re-evaluates against the
+                        // winner.
+                        continue;
+                    }
+                    // Still colliding after retries — surface the db
+                    // error rather than a misleading "already exists"
+                    // (the caller DID pass --overwrite).
+                    Err(sqlx::Error::Database(e).into())
+                } else {
+                    // Collision on (name, aih, 1): the schedule already
+                    // exists — report absence so the handler can
+                    // surface a clean error.
+                    Ok(None)
+                }
+            }
+            Err(e) => Err(e.into()),
+        };
     }
 }
 
-/// List `schedules` matching the supplied filters. Every filter is
-/// optional and composes additively — the SQL is one statement that
-/// gates each predicate on whether the corresponding bind is active
-/// (0 = inactive bool flag, `NULL` = unset depth/count).
+/// List `schedules` matching the supplied filters. Only the newest
+/// version of each `(name, aih)` is visible; readiness derives from
+/// each row's newest `tasks_runs` entry. Every filter is optional and
+/// composes additively — the SQL is one statement that gates each
+/// predicate on whether the corresponding bind is active (0 = inactive
+/// bool flag, `NULL` = unset after_id/count).
 ///
-/// * `parent` + `max_depth`: hierarchy scope.
+/// * `hierarchies`: exact-match AIH scope (no subtree descent).
 /// * `oneshot_only` / `interval_only`: kind filter (mutually exclusive
 ///   at the CLI layer; both `false` = no kind filter).
 /// * `pending_only` / `exhausted_only`: readiness filter (same).
-/// * `offset` / `count`: pagination. `count = None` binds `-1` to
-///   LIMIT for unlimited (postgres treats negative LIMIT as
-///   unlimited via `LIMIT NULL`; we pass NULL explicitly).
+/// * `after_id` / `count`: keyset pagination by ascending row id.
+///   `count = None` binds `NULL` to LIMIT for unlimited.
 pub async fn list_schedules(
     pool: &Pool,
     hierarchies: &[String],
@@ -164,45 +204,54 @@ pub async fn list_schedules(
 ) -> Result<Vec<ListedSchedule>, Error> {
     let count_param: Option<i64> = count.map(|c| c as i64);
 
-    // Exact-AIH scope (`= ANY($1)`, no subtree descent), the kind /
-    // readiness short-circuits (`($N = 0 OR …)`, $5 = now), and keyset
-    // pagination forward by ascending id (`id > COALESCE($7, 0)`).
-    // `LIMIT $8` is `NULL` when `count` is `None` → unlimited.
-    let rows = sqlx::query(
-        "SELECT id, \
-                name, \
-                agent_instance_hierarchy, \
-                command, \
-                description, \
-                created_at, \
-                last_ran_at, \
-                interval_seconds, \
-                plugin_owner, \
-                plugin_repository, \
-                plugin_version, \
-                version \
-         FROM schedules \
-         WHERE agent_instance_hierarchy = ANY($1) \
-             AND ($2 = 0 OR interval_seconds IS NULL) \
-             AND ($3 = 0 OR interval_seconds IS NOT NULL) \
+    // Exact-AIH scope (`= ANY($1)`, no subtree descent), only the
+    // newest version of each (name, aih) (older versions are
+    // shadowed), `last_ran_at` derived from the newest `tasks_runs`
+    // entry via LATERAL, the kind / readiness short-circuits
+    // (`($N = 0 OR …)`, $5 = now), and keyset pagination forward by
+    // ascending id (`id > COALESCE($7, 0)`). `LIMIT $8` is `NULL` when
+    // `count` is `None` → unlimited.
+    let query = format!(
+        "SELECT s.id, \
+                s.name, \
+                s.agent_instance_hierarchy, \
+                s.command, \
+                s.description, \
+                s.created_at, \
+                lr.last_ran_at, \
+                s.interval_seconds, \
+                s.plugin_owner, \
+                s.plugin_repository, \
+                s.plugin_version, \
+                s.version \
+         FROM schedules s \
+         LEFT JOIN LATERAL ( \
+             SELECT MAX(r.ran_at) AS last_ran_at \
+             FROM tasks_runs r WHERE r.schedule_id = s.id \
+         ) lr ON TRUE \
+         WHERE s.agent_instance_hierarchy = ANY($1) \
+             AND {LATEST_VERSION_PREDICATE} \
+             AND ($2 = 0 OR s.interval_seconds IS NULL) \
+             AND ($3 = 0 OR s.interval_seconds IS NOT NULL) \
              AND ($4 = 0 OR ( \
-                 (interval_seconds IS NULL AND last_ran_at IS NULL) \
+                 (s.interval_seconds IS NULL AND lr.last_ran_at IS NULL) \
                  OR \
-                 (interval_seconds IS NOT NULL \
-                  AND (last_ran_at IS NULL \
-                       OR ($5 - last_ran_at) >= interval_seconds)) \
+                 (s.interval_seconds IS NOT NULL \
+                  AND (lr.last_ran_at IS NULL \
+                       OR ($5 - lr.last_ran_at) >= s.interval_seconds)) \
              )) \
              AND ($6 = 0 OR ( \
-                 (interval_seconds IS NULL AND last_ran_at IS NOT NULL) \
+                 (s.interval_seconds IS NULL AND lr.last_ran_at IS NOT NULL) \
                  OR \
-                 (interval_seconds IS NOT NULL \
-                  AND last_ran_at IS NOT NULL \
-                  AND ($5 - last_ran_at) < interval_seconds) \
+                 (s.interval_seconds IS NOT NULL \
+                  AND lr.last_ran_at IS NOT NULL \
+                  AND ($5 - lr.last_ran_at) < s.interval_seconds) \
              )) \
-             AND id > COALESCE($7, 0) \
-         ORDER BY id ASC \
+             AND s.id > COALESCE($7, 0) \
+         ORDER BY s.id ASC \
          LIMIT $8",
-    )
+    );
+    let rows = sqlx::query(&query)
     .bind(hierarchies)
     .bind(oneshot_only as i64)
     .bind(interval_only as i64)
@@ -249,122 +298,93 @@ pub async fn list_schedules(
     Ok(out)
 }
 
-/// Atomically: capture every pending schedule in `parent`'s subtree
-/// (its own AIH or any descendant), bump every captured row's
-/// `last_ran_at = now`, and delete any captured oneshots. Returns the
-/// captured rows for the caller to fire.
+/// Atomically claim every pending schedule in `parent`'s subtree (its
+/// own AIH or any descendant): ONE statement both selects the eligible
+/// rows and inserts their `tasks_runs` rows, so each returned `RunRow`
+/// carries the freshly-minted `run_id`. Schedules are never updated or
+/// deleted by a run — exhaustion is purely "has a run" (oneshots) /
+/// "newest run too recent" (recurring), and only the newest version of
+/// each (name, aih) is eligible.
 ///
-/// "Pending" means: oneshots with `last_ran_at IS NULL`, or recurring
-/// rows where `now - last_ran_at >= interval_seconds` (or
-/// `last_ran_at IS NULL`). Same predicate `agents tasks list --pending`
-/// matches. The captured `plugin` triple is re-installed on each task's
-/// run ctx by the handler.
-pub async fn collect_and_mark_pending(
-    pool: &Pool,
-    parent: &str,
-) -> Result<Vec<RunRow>, Error> {
+/// The transaction opens with `pg_advisory_xact_lock` so concurrent
+/// `tasks run` callers fully serialize: the second claimer sees the
+/// first's `tasks_runs` rows and excludes those schedules. (Row locks
+/// can't do this — eligibility reads a DIFFERENT table than the one
+/// the claim writes, so a blocked reader would re-check a schedules
+/// row that never changed and double-claim.)
+pub async fn claim_pending(pool: &Pool, parent: &str) -> Result<Vec<RunRow>, Error> {
     let now = now_seconds();
 
     let mut tx = pool.begin().await?;
 
-    // 1. Capture rows: `parent`'s own AIH plus every descendant, no
-    //    depth cap.
-    let rows = sqlx::query(
-        "SELECT id, name, agent_instance_hierarchy, command, agent_arguments, \
-                plugin_owner, plugin_repository, plugin_version \
-         FROM schedules \
-         WHERE \
-             ( \
-                 agent_instance_hierarchy = $1 \
-                 OR agent_instance_hierarchy LIKE ($1 || '/%') \
-             ) \
-             AND ( \
-                 (interval_seconds IS NULL AND last_ran_at IS NULL) \
-                 OR \
-                 (interval_seconds IS NOT NULL \
-                  AND (last_ran_at IS NULL \
-                       OR ($2 - last_ran_at) >= interval_seconds)) \
-             ) \
-         ORDER BY id ASC",
-    )
-    .bind(parent)
-    .bind(now)
-    .fetch_all(&mut *tx)
-    .await?;
-
-    if rows.is_empty() {
-        tx.commit().await?;
-        return Ok(Vec::new());
-    }
-
-    // 2. Bump last_ran_at + 3. Delete oneshots. Loop per-id since the
-    //    delete predicate is also per-row.
-    type Captured = (
-        i64,
-        String,
-        String,
-        String,
-        String,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    );
-    let mut captured: Vec<Captured> = Vec::with_capacity(rows.len());
-    for row in rows {
-        let id: i64 = row.try_get(0)?;
-        let name: String = row.try_get(1)?;
-        let agent_instance_hierarchy: String = row.try_get(2)?;
-        let command_json: String = row.try_get(3)?;
-        let agent_arguments_json: String = row.try_get(4)?;
-        let plugin_owner: Option<String> = row.try_get(5)?;
-        let plugin_repository: Option<String> = row.try_get(6)?;
-        let plugin_version: Option<String> = row.try_get(7)?;
-        captured.push((
-            id,
-            name,
-            agent_instance_hierarchy,
-            command_json,
-            agent_arguments_json,
-            plugin_owner,
-            plugin_repository,
-            plugin_version,
-        ));
-    }
-    for (id, ..) in &captured {
-        sqlx::query("UPDATE schedules SET last_ran_at = $1 WHERE id = $2")
-            .bind(now)
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
-        sqlx::query(
-            "DELETE FROM schedules WHERE id = $1 AND interval_seconds IS NULL",
-        )
-        .bind(id)
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(CLAIM_LOCK_KEY)
         .execute(&mut *tx)
         .await?;
-    }
+
+    let query = format!(
+        "WITH eligible AS ( \
+             SELECT s.id, s.name, s.agent_instance_hierarchy, s.version, \
+                    s.command, s.agent_arguments, \
+                    s.plugin_owner, s.plugin_repository, s.plugin_version \
+             FROM schedules s \
+             WHERE ( \
+                     s.agent_instance_hierarchy = $1 \
+                     OR s.agent_instance_hierarchy LIKE ($1 || '/%') \
+                 ) \
+                 AND {LATEST_VERSION_PREDICATE} \
+                 AND ( \
+                     (s.interval_seconds IS NULL \
+                      AND NOT EXISTS ( \
+                          SELECT 1 FROM tasks_runs r WHERE r.schedule_id = s.id \
+                      )) \
+                     OR \
+                     (s.interval_seconds IS NOT NULL \
+                      AND COALESCE( \
+                          $2 - (SELECT MAX(r.ran_at) FROM tasks_runs r \
+                                WHERE r.schedule_id = s.id) \
+                              >= s.interval_seconds, \
+                          TRUE)) \
+                 ) \
+         ), \
+         ins AS ( \
+             INSERT INTO tasks_runs (schedule_id, ran_at) \
+             SELECT id, $2 FROM eligible \
+             RETURNING id AS run_id, schedule_id \
+         ) \
+         SELECT ins.run_id, e.name, e.agent_instance_hierarchy, e.version, \
+                e.command, e.agent_arguments, \
+                e.plugin_owner, e.plugin_repository, e.plugin_version \
+         FROM eligible e \
+         JOIN ins ON ins.schedule_id = e.id \
+         ORDER BY e.id ASC",
+    );
+    let rows = sqlx::query(&query)
+        .bind(parent)
+        .bind(now)
+        .fetch_all(&mut *tx)
+        .await?;
 
     tx.commit().await?;
 
-    // 4. Decode and return.
-    let mut out = Vec::with_capacity(captured.len());
-    for (
-        id,
-        name,
-        agent_instance_hierarchy,
-        command_json,
-        agent_arguments_json,
-        plugin_owner,
-        plugin_repository,
-        plugin_version,
-    ) in captured
-    {
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let run_id: i64 = row.try_get(0)?;
+        let name: String = row.try_get(1)?;
+        let agent_instance_hierarchy: String = row.try_get(2)?;
+        let version: i64 = row.try_get(3)?;
+        let command_json: String = row.try_get(4)?;
+        let agent_arguments_json: String = row.try_get(5)?;
+        let plugin_owner: Option<String> = row.try_get(6)?;
+        let plugin_repository: Option<String> = row.try_get(7)?;
+        let plugin_version: Option<String> = row.try_get(8)?;
         let command: Vec<String> = serde_json::from_str(&command_json)?;
         let agent_arguments: AgentArguments = serde_json::from_str(&agent_arguments_json)?;
         out.push(RunRow {
-            id,
+            run_id,
             name,
             agent_instance_hierarchy,
+            version,
             command,
             agent_arguments,
             plugin: crate::plugin_path::PluginPath::from_parts(
@@ -375,4 +395,16 @@ pub async fn collect_and_mark_pending(
         });
     }
     Ok(out)
+}
+
+/// Append one emitted item to a run's log. `value` is the serialized
+/// `tasks::run::ResponseItem` exactly as it crossed the wire.
+pub async fn insert_task_log(pool: &Pool, run_id: i64, value: &str) -> Result<(), Error> {
+    sqlx::query("INSERT INTO tasks_logs (run_id, value, created_at) VALUES ($1, $2, $3)")
+        .bind(run_id)
+        .bind(value)
+        .bind(now_seconds())
+        .execute(&**pool)
+        .await?;
+    Ok(())
 }

--- a/objectiveai-cli/src/db/tasks.rs
+++ b/objectiveai-cli/src/db/tasks.rs
@@ -39,8 +39,12 @@ pub struct ListedSchedule {
 pub struct RunRow {
     pub id: i64,
     pub name: String,
+    pub agent_instance_hierarchy: String,
     pub command: Vec<String>,
     pub agent_arguments: AgentArguments,
+    /// The plugin that registered this schedule, if any — re-installed
+    /// on the run ctx so the task fires on behalf of that plugin.
+    pub plugin: Option<crate::plugin_path::PluginPath>,
 }
 
 fn now_seconds() -> i64 {
@@ -245,56 +249,45 @@ pub async fn list_schedules(
     Ok(out)
 }
 
-/// Atomically: capture every pending row in scope, bump every captured
-/// row's `last_ran_at = now`, and delete any captured oneshots.
-/// Returns the captured rows for the caller to fire.
+/// Atomically: capture every pending schedule in `parent`'s subtree
+/// (its own AIH or any descendant), bump every captured row's
+/// `last_ran_at = now`, and delete any captured oneshots. Returns the
+/// captured rows for the caller to fire.
 ///
 /// "Pending" means: oneshots with `last_ran_at IS NULL`, or recurring
 /// rows where `now - last_ran_at >= interval_seconds` (or
 /// `last_ran_at IS NULL`). Same predicate `agents tasks list --pending`
-/// matches.
+/// matches. The captured `plugin` triple is re-installed on each task's
+/// run ctx by the handler.
 pub async fn collect_and_mark_pending(
     pool: &Pool,
     parent: &str,
-    max_depth: Option<u64>,
 ) -> Result<Vec<RunRow>, Error> {
     let now = now_seconds();
-    let max_depth_param: Option<i64> = max_depth.map(|d| d as i64);
 
     let mut tx = pool.begin().await?;
 
-    // 1. Capture rows.
+    // 1. Capture rows: `parent`'s own AIH plus every descendant, no
+    //    depth cap.
     let rows = sqlx::query(
-        "SELECT id, name, command, agent_arguments \
+        "SELECT id, name, agent_instance_hierarchy, command, agent_arguments, \
+                plugin_owner, plugin_repository, plugin_version \
          FROM schedules \
          WHERE \
              ( \
                  agent_instance_hierarchy = $1 \
-                 OR ( \
-                     agent_instance_hierarchy LIKE ($1 || '/%') \
-                     AND ( \
-                         $2::bigint IS NULL \
-                         OR \
-                         ( \
-                             (length(agent_instance_hierarchy) \
-                              - length(replace(agent_instance_hierarchy, '/', ''))) \
-                             - (length($1) \
-                                - length(replace($1, '/', ''))) \
-                         ) <= $2 \
-                     ) \
-                 ) \
+                 OR agent_instance_hierarchy LIKE ($1 || '/%') \
              ) \
              AND ( \
                  (interval_seconds IS NULL AND last_ran_at IS NULL) \
                  OR \
                  (interval_seconds IS NOT NULL \
                   AND (last_ran_at IS NULL \
-                       OR ($3 - last_ran_at) >= interval_seconds)) \
+                       OR ($2 - last_ran_at) >= interval_seconds)) \
              ) \
          ORDER BY id ASC",
     )
     .bind(parent)
-    .bind(max_depth_param)
     .bind(now)
     .fetch_all(&mut *tx)
     .await?;
@@ -306,15 +299,38 @@ pub async fn collect_and_mark_pending(
 
     // 2. Bump last_ran_at + 3. Delete oneshots. Loop per-id since the
     //    delete predicate is also per-row.
-    let mut captured: Vec<(i64, String, String, String)> = Vec::with_capacity(rows.len());
+    type Captured = (
+        i64,
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    );
+    let mut captured: Vec<Captured> = Vec::with_capacity(rows.len());
     for row in rows {
         let id: i64 = row.try_get(0)?;
         let name: String = row.try_get(1)?;
-        let command_json: String = row.try_get(2)?;
-        let agent_arguments_json: String = row.try_get(3)?;
-        captured.push((id, name, command_json, agent_arguments_json));
+        let agent_instance_hierarchy: String = row.try_get(2)?;
+        let command_json: String = row.try_get(3)?;
+        let agent_arguments_json: String = row.try_get(4)?;
+        let plugin_owner: Option<String> = row.try_get(5)?;
+        let plugin_repository: Option<String> = row.try_get(6)?;
+        let plugin_version: Option<String> = row.try_get(7)?;
+        captured.push((
+            id,
+            name,
+            agent_instance_hierarchy,
+            command_json,
+            agent_arguments_json,
+            plugin_owner,
+            plugin_repository,
+            plugin_version,
+        ));
     }
-    for (id, _, _, _) in &captured {
+    for (id, ..) in &captured {
         sqlx::query("UPDATE schedules SET last_ran_at = $1 WHERE id = $2")
             .bind(now)
             .bind(id)
@@ -332,14 +348,30 @@ pub async fn collect_and_mark_pending(
 
     // 4. Decode and return.
     let mut out = Vec::with_capacity(captured.len());
-    for (id, name, command_json, agent_arguments_json) in captured {
+    for (
+        id,
+        name,
+        agent_instance_hierarchy,
+        command_json,
+        agent_arguments_json,
+        plugin_owner,
+        plugin_repository,
+        plugin_version,
+    ) in captured
+    {
         let command: Vec<String> = serde_json::from_str(&command_json)?;
         let agent_arguments: AgentArguments = serde_json::from_str(&agent_arguments_json)?;
         out.push(RunRow {
             id,
             name,
+            agent_instance_hierarchy,
             command,
             agent_arguments,
+            plugin: crate::plugin_path::PluginPath::from_parts(
+                plugin_owner,
+                plugin_repository,
+                plugin_version,
+            ),
         });
     }
     Ok(out)

--- a/objectiveai-cli/src/db/tasks.rs
+++ b/objectiveai-cli/src/db/tasks.rs
@@ -8,6 +8,7 @@
 
 use objectiveai_sdk::cli::command::AgentArguments;
 use sqlx::Row as _;
+use sqlx::error::DatabaseError as _;
 
 use super::{Error, Pool};
 
@@ -23,6 +24,12 @@ pub struct ListedSchedule {
     pub created_at: i64,
     pub last_ran_at: Option<i64>,
     pub interval_seconds: Option<u64>,
+    /// Overwrite count: `1` on first insert, incremented on each
+    /// `--overwrite` replacement of this `(name, aih)` row.
+    pub version: i64,
+    /// The plugin that registered this schedule, if any. `Some` iff all
+    /// three `plugin_*` columns are set (the table CHECK enforces it).
+    pub plugin: Option<crate::plugin_path::PluginPath>,
 }
 
 /// Subset of a schedule row that `agents tasks run` needs to fire one
@@ -51,6 +58,13 @@ fn now_seconds() -> i64 {
 /// runner will exec). `agent_arguments` is JSON-serialised verbatim —
 /// the runner re-installs each `Some(_)` field as the matching env var
 /// when the schedule fires.
+///
+/// `(name, agent_instance_hierarchy)` is unique. When `overwrite` is
+/// false a collision yields `Ok(None)` so the caller can raise a
+/// friendly "already exists" error; when true the existing row is
+/// replaced in place and its `version` bumped (`last_ran_at` reset so
+/// the redefined schedule fires fresh). A brand-new row starts at
+/// `version = 1`.
 pub async fn insert_schedule(
     pool: &Pool,
     name: &str,
@@ -59,26 +73,68 @@ pub async fn insert_schedule(
     agent_instance_hierarchy: &str,
     interval_seconds: Option<u64>,
     agent_arguments: &AgentArguments,
-) -> Result<i64, Error> {
+    plugin: Option<&crate::plugin_path::PluginPath>,
+    overwrite: bool,
+) -> Result<Option<i64>, Error> {
     let command_json = serde_json::to_string(command)?;
     let agent_arguments_json = serde_json::to_string(agent_arguments)?;
     let interval_param: Option<i64> = interval_seconds.map(|s| s as i64);
-    let id: i64 = sqlx::query_scalar(
-        "INSERT INTO schedules \
-         (name, command, description, agent_instance_hierarchy, interval_seconds, agent_arguments, created_at) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7) \
-         RETURNING id",
-    )
-    .bind(name)
-    .bind(command_json)
-    .bind(description)
-    .bind(agent_instance_hierarchy)
-    .bind(interval_param)
-    .bind(agent_arguments_json)
-    .bind(now_seconds())
-    .fetch_one(&**pool)
-    .await?;
-    Ok(id)
+    let (plugin_owner, plugin_repository, plugin_version) = match plugin {
+        Some(p) => (
+            Some(p.owner.as_str()),
+            Some(p.repository.as_str()),
+            Some(p.version.as_str()),
+        ),
+        None => (None, None, None),
+    };
+
+    // `version` is omitted from the column list so the table's
+    // `DEFAULT 1` applies on a fresh insert; the overwrite path bumps
+    // it explicitly off the existing row.
+    let columns = "(name, command, description, agent_instance_hierarchy, interval_seconds, \
+                    agent_arguments, plugin_owner, plugin_repository, plugin_version, created_at)";
+    let values = "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+
+    let query = if overwrite {
+        format!(
+            "INSERT INTO schedules {columns} {values} \
+             ON CONFLICT (name, agent_instance_hierarchy) DO UPDATE SET \
+                 command = EXCLUDED.command, \
+                 description = EXCLUDED.description, \
+                 interval_seconds = EXCLUDED.interval_seconds, \
+                 agent_arguments = EXCLUDED.agent_arguments, \
+                 plugin_owner = EXCLUDED.plugin_owner, \
+                 plugin_repository = EXCLUDED.plugin_repository, \
+                 plugin_version = EXCLUDED.plugin_version, \
+                 last_ran_at = NULL, \
+                 version = schedules.version + 1 \
+             RETURNING id"
+        )
+    } else {
+        format!("INSERT INTO schedules {columns} {values} RETURNING id")
+    };
+
+    let result = sqlx::query_scalar::<_, i64>(&query)
+        .bind(name)
+        .bind(command_json)
+        .bind(description)
+        .bind(agent_instance_hierarchy)
+        .bind(interval_param)
+        .bind(agent_arguments_json)
+        .bind(plugin_owner)
+        .bind(plugin_repository)
+        .bind(plugin_version)
+        .bind(now_seconds())
+        .fetch_one(&**pool)
+        .await;
+
+    match result {
+        Ok(id) => Ok(Some(id)),
+        // Non-overwrite collision on the (name, aih) unique constraint:
+        // report absence so the handler can surface a clean error.
+        Err(sqlx::Error::Database(e)) if e.is_unique_violation() => Ok(None),
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// List `schedules` matching the supplied filters. Every filter is
@@ -120,7 +176,11 @@ pub async fn list_schedules(
                 description, \
                 created_at, \
                 last_ran_at, \
-                interval_seconds \
+                interval_seconds, \
+                plugin_owner, \
+                plugin_repository, \
+                plugin_version, \
+                version \
          FROM schedules \
          WHERE \
              /* Hierarchy + depth filter. Inclusive of parent itself. */ \
@@ -181,6 +241,10 @@ pub async fn list_schedules(
         let created_at: i64 = row.try_get(5)?;
         let last_ran_at: Option<i64> = row.try_get(6)?;
         let interval_seconds: Option<i64> = row.try_get(7)?;
+        let plugin_owner: Option<String> = row.try_get(8)?;
+        let plugin_repository: Option<String> = row.try_get(9)?;
+        let plugin_version: Option<String> = row.try_get(10)?;
+        let version: i64 = row.try_get(11)?;
         let command: Vec<String> = serde_json::from_str(&command_json)?;
         out.push(ListedSchedule {
             id,
@@ -191,6 +255,12 @@ pub async fn list_schedules(
             created_at,
             last_ran_at,
             interval_seconds: interval_seconds.map(|s| s as u64),
+            version,
+            plugin: crate::plugin_path::PluginPath::from_parts(
+                plugin_owner,
+                plugin_repository,
+                plugin_version,
+            ),
         });
     }
     Ok(out)

--- a/objectiveai-cli/src/error.rs
+++ b/objectiveai-cli/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
     PluginRead(std::io::Error),
     #[error("plugin exited with non-zero status: {0}")]
     PluginExit(i32),
+    #[error("plugins may not invoke `{0}` commands")]
+    PluginCommandForbidden(&'static str),
     #[error("tool not found: {0}")]
     ToolNotFound(String),
     #[error("failed to spawn tool: {0}")]

--- a/objectiveai-cli/src/error.rs
+++ b/objectiveai-cli/src/error.rs
@@ -126,6 +126,13 @@ pub enum Error {
         sender_agent_instance_hierarchy: String,
         caller_agent_instance_hierarchy: String,
     },
+    #[error(
+        "a schedule named {name:?} already exists for {agent_instance_hierarchy:?}; pass --overwrite to replace it"
+    )]
+    ScheduleAlreadyExists {
+        name: String,
+        agent_instance_hierarchy: String,
+    },
     #[error("embedded postgres bootstrap failed: {0}")]
     PostgresBootstrap(String),
     #[error("db: {0}")]

--- a/objectiveai-mcp/src/objectiveai.rs
+++ b/objectiveai-mcp/src/objectiveai.rs
@@ -41,17 +41,13 @@ pub struct ObjectiveAiRequest {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct PluginRequest {
-    #[schemars(
-        description = "Args forwarded to the plugin's argv (prefixed automatically with `plugins run <name>` when invoking the CLI)."
-    )]
+    #[schemars(description = "Args forwarded to the plugin binary's argv.")]
     pub args: Vec<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ToolRequest {
-    #[schemars(
-        description = "Args forwarded to the tool's argv (prefixed automatically with `tools run <name>` when invoking the CLI)."
-    )]
+    #[schemars(description = "Args appended verbatim to the tool's exec command.")]
     pub args: Vec<String>,
 }
 

--- a/objectiveai-sdk-rs/src/cli/command/agents/logs/read/all/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/logs/read/all/mod.rs
@@ -119,8 +119,7 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub after_id: Option<i64>,
-    /// Cap on rows scanned per target. Defaults to 1000 server-side
-    /// when omitted.
+    /// Cap on rows scanned per target. `None` = unlimited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub limit: Option<i64>,

--- a/objectiveai-sdk-rs/src/cli/command/agents/logs/read/pending/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/logs/read/pending/mod.rs
@@ -16,8 +16,7 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub after_id: Option<i64>,
-    /// Cap on rows scanned per target. Defaults to 1000 server-side
-    /// when omitted.
+    /// Cap on rows scanned per target. `None` = unlimited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub limit: Option<i64>,

--- a/objectiveai-sdk-rs/src/cli/command/agents/queue/deliver/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/queue/deliver/mod.rs
@@ -1,0 +1,238 @@
+//! `agents queue deliver` — wake every queue-pending descendant
+//! agent of the caller.
+//!
+//! The handler enumerates the unique AIHs with active queued prompts
+//! that are STRICT descendants of the caller (the caller itself is
+//! excluded) and, per AIH, try-acquires the agent's file lock with no
+//! waiting: a live owner yields [`AgentActiveResponseItem`]; winning
+//! the lock yields [`AgentSpawnedResponseItem`] and runs the same
+//! spawn machinery `agents spawn` / `agents message` use (empty
+//! messages + the stored continuation), streaming each spawn item as
+//! a [`ValueResponseItem`] and releasing the lock when that task's
+//! stream ends. Once EVERY target has resolved (active or spawned),
+//! the bare string `"AllAgentsActive"` is emitted.
+//!
+//! Two modes, selected by `dangerous_advanced.stream_spawns`:
+//! * unset/false (the default, user-facing): re-exec the cli binary
+//!   as a detached orphan with `stream_spawns = true` and emit the
+//!   child's items up to and including `AllAgentsActive`, then
+//!   return — the orphan keeps running the spawns to completion.
+//! * true (the re-exec'd child): run the full delivery in-process and
+//!   stream everything, spawn output included.
+
+use crate::cli::command::CommandRequest;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.Request")]
+pub struct Request {
+    pub path_type: Path,
+    pub dangerous_advanced: Option<RequestDangerousAdvanced>,
+    pub jq: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.Path")]
+pub enum Path {
+    #[serde(rename = "agents/queue/deliver")]
+    AgentsQueueDeliver,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.RequestDangerousAdvanced")]
+pub struct RequestDangerousAdvanced {
+    /// Run the delivery in-process and stream every spawned agent's
+    /// output to completion. Unset/false re-execs a detached child
+    /// with this set and returns at its `AllAgentsActive` marker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("omitempty" = true))]
+    pub stream_spawns: Option<bool>,
+}
+
+impl CommandRequest for Request {
+    fn into_command(&self) -> Vec<String> {
+        let mut argv = vec![
+            "agents".to_string(),
+            "queue".to_string(),
+            "deliver".to_string(),
+        ];
+        if let Some(advanced) = &self.dangerous_advanced {
+            argv.push("--dangerous-advanced".to_string());
+            argv.push(
+                serde_json::to_string(advanced)
+                    .expect("RequestDangerousAdvanced serializes"),
+            );
+        }
+        if let Some(jq) = &self.jq {
+            argv.push("--jq".to_string());
+            argv.push(jq.clone());
+        }
+        argv
+    }
+}
+
+/// One stream item from `agents queue deliver`. Untagged — the
+/// variants are disjoint on the wire: `Value` requires `value`,
+/// `AgentActive` / `AgentSpawned` carry distinct `type` markers, and
+/// `AllAgentsActive` is the bare string `"AllAgentsActive"`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+#[schemars(rename = "cli.command.agents.queue.deliver.ResponseItem")]
+pub enum ResponseItem {
+    #[schemars(title = "Value")]
+    Value(ValueResponseItem),
+    #[schemars(title = "AgentActive")]
+    AgentActive(AgentActiveResponseItem),
+    #[schemars(title = "AgentSpawned")]
+    AgentSpawned(AgentSpawnedResponseItem),
+    #[schemars(title = "AllAgentsActive")]
+    AllAgentsActive(AllAgentsActive),
+}
+
+/// One output item from one delivered agent's spawn stream. `value`
+/// is the typed root [`crate::cli::command::ResponseItem`] (the spawn
+/// item wrapped at the root) — boxed because the root union
+/// transitively contains *this* type (`agents → queue → deliver`),
+/// and boxing is what makes the recursion sized.
+///
+/// The `value` field's JSON schema is opaqued to `serde_json::Value`
+/// (renders as bare `{}` aka JsonValue) so the published schema
+/// doesn't inline the entire root union — that's the TS7056 blowup
+/// the root and tier aggregates dodge by being `json_schema_ignore`.
+/// Downstream SDKs see `value: JsonValue` on the typed `execute`
+/// path; consumers that want to peer inside parse it case-by-case.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.ValueResponseItem")]
+pub struct ValueResponseItem {
+    /// The delivered agent's `agent_instance_hierarchy`.
+    pub agent_instance_hierarchy: String,
+    /// The typed root item the spawn emitted.
+    #[schemars(with = "serde_json::Value")]
+    pub value: Box<crate::cli::command::ResponseItem>,
+}
+
+/// This agent's lock was held by a live owner — it is already active
+/// and will drain its own queue; nothing was spawned for it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.AgentActiveResponseItem")]
+pub struct AgentActiveResponseItem {
+    pub r#type: AgentActiveType,
+    pub agent_instance_hierarchy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.AgentActiveType")]
+pub enum AgentActiveType {
+    #[serde(rename = "AgentActive")]
+    AgentActive,
+}
+
+/// This agent's lock was won and its spawn has started; its output
+/// follows as [`ValueResponseItem`]s (in `stream_spawns` mode).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.AgentSpawnedResponseItem")]
+pub struct AgentSpawnedResponseItem {
+    pub r#type: AgentSpawnedType,
+    pub agent_instance_hierarchy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.AgentSpawnedType")]
+pub enum AgentSpawnedType {
+    #[serde(rename = "AgentSpawned")]
+    AgentSpawned,
+}
+
+/// Every target has resolved to active-or-spawned. Wire shape is the
+/// bare string `"AllAgentsActive"` (a one-variant enum — a unit
+/// variant in the untagged [`ResponseItem`] would serialize as
+/// `null`, not the marker string). The detached default mode stops
+/// reading its child at this item.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.AllAgentsActive")]
+pub enum AllAgentsActive {
+    AllAgentsActive,
+}
+
+#[derive(clap::Args)]
+pub struct Args {
+    /// Raw JSON for `RequestDangerousAdvanced` (e.g.
+    /// `{"stream_spawns":true}`).
+    #[arg(long)]
+    pub dangerous_advanced: Option<String>,
+    /// jq filter applied to the JSON output.
+    #[arg(long)]
+    pub jq: Option<String>,
+}
+
+#[derive(clap::Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Command {
+    #[command(flatten)]
+    pub args: Args,
+    #[command(subcommand)]
+    pub schema: Option<Schema>,
+}
+
+#[derive(clap::Subcommand)]
+pub enum Schema {
+    /// Emit the JSON Schema for this leaf's `Request` type and exit.
+    RequestSchema(request_schema::Args),
+    /// Emit the JSON Schema for this leaf's `Response` type and exit.
+    ResponseSchema(response_schema::Args),
+}
+
+impl TryFrom<Args> for Request {
+    type Error = crate::cli::command::FromArgsError;
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let dangerous_advanced: Option<RequestDangerousAdvanced> =
+            if let Some(s) = args.dangerous_advanced {
+                let mut de = serde_json::Deserializer::from_str(&s);
+                let v = serde_path_to_error::deserialize(&mut de).map_err(|source| {
+                    crate::cli::command::FromArgsError {
+                        field: "dangerous_advanced",
+                        source: source.into(),
+                    }
+                })?;
+                Some(v)
+            } else {
+                None
+            };
+        Ok(Self {
+            path_type: Path::AgentsQueueDeliver,
+            dangerous_advanced,
+            jq: args.jq,
+        })
+    }
+}
+
+#[cfg(feature = "cli-executor")]
+pub async fn execute<E: crate::cli::command::CommandExecutor>(
+    executor: &E,
+    mut request: Request,
+    agent_arguments: Option<&crate::cli::command::AgentArguments>,
+) -> Result<E::Stream<ResponseItem>, E::Error> {
+    request.jq = None;
+    executor.execute(request, agent_arguments).await
+}
+
+#[cfg(feature = "cli-executor")]
+pub async fn execute_jq<E: crate::cli::command::CommandExecutor>(
+    executor: &E,
+    mut request: Request,
+    jq: String,
+    agent_arguments: Option<&crate::cli::command::AgentArguments>,
+) -> Result<E::Stream<serde_json::Value>, E::Error> {
+    request.jq = Some(jq);
+    executor.execute(request, agent_arguments).await
+}
+
+#[cfg(feature = "mcp")]
+impl crate::cli::command::CommandResponse for ResponseItem {
+    fn into_mcp(self) -> crate::cli::command::McpResponseItem {
+        crate::cli::command::McpResponseItem::JSONL(serde_json::to_value(self).unwrap())
+    }
+}
+
+pub mod request_schema;
+
+pub mod response_schema;

--- a/objectiveai-sdk-rs/src/cli/command/agents/queue/deliver/request_schema/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/queue/deliver/request_schema/mod.rs
@@ -1,0 +1,69 @@
+use crate::cli::command::CommandRequest;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.request_schema.Request")]
+pub struct Request {
+    pub path_type: Path,
+    pub jq: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.request_schema.Path")]
+pub enum Path {
+    #[serde(rename = "agents/queue/deliver/request_schema")]
+    AgentsQueueDeliverRequestSchema,
+}
+
+#[derive(clap::Args)]
+pub struct Args {
+    #[arg(long)]
+    pub jq: Option<String>,
+}
+
+impl CommandRequest for Request {
+    fn into_command(&self) -> Vec<String> {
+        let mut argv: Vec<String> =
+            vec!["agents", "queue", "deliver", "request-schema"]
+                .into_iter()
+                .map(String::from)
+                .collect();
+        if let Some(jq) = &self.jq {
+            argv.push("--jq".to_string());
+            argv.push(jq.clone());
+        }
+        argv
+    }
+}
+
+pub type Response = crate::cli::command::ResponseSchema;
+
+impl TryFrom<Args> for Request {
+    type Error = crate::cli::command::FromArgsError;
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        Ok(Self {
+            path_type: Path::AgentsQueueDeliverRequestSchema,
+            jq: args.jq,
+        })
+    }
+}
+
+#[cfg(feature = "cli-executor")]
+pub async fn execute<E: crate::cli::command::CommandExecutor>(
+    executor: &E,
+    mut request: Request,
+    agent_arguments: Option<&crate::cli::command::AgentArguments>,
+) -> Result<Response, E::Error> {
+    request.jq = None;
+    executor.execute_one(request, agent_arguments).await
+}
+
+#[cfg(feature = "cli-executor")]
+pub async fn execute_jq<E: crate::cli::command::CommandExecutor>(
+    executor: &E,
+    mut request: Request,
+    jq: String,
+    agent_arguments: Option<&crate::cli::command::AgentArguments>,
+) -> Result<serde_json::Value, E::Error> {
+    request.jq = Some(jq);
+    executor.execute_one(request, agent_arguments).await
+}

--- a/objectiveai-sdk-rs/src/cli/command/agents/queue/deliver/response_schema/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/queue/deliver/response_schema/mod.rs
@@ -1,0 +1,69 @@
+use crate::cli::command::CommandRequest;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.response_schema.Request")]
+pub struct Request {
+    pub path_type: Path,
+    pub jq: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.agents.queue.deliver.response_schema.Path")]
+pub enum Path {
+    #[serde(rename = "agents/queue/deliver/response_schema")]
+    AgentsQueueDeliverResponseSchema,
+}
+
+#[derive(clap::Args)]
+pub struct Args {
+    #[arg(long)]
+    pub jq: Option<String>,
+}
+
+impl CommandRequest for Request {
+    fn into_command(&self) -> Vec<String> {
+        let mut argv: Vec<String> =
+            vec!["agents", "queue", "deliver", "response-schema"]
+                .into_iter()
+                .map(String::from)
+                .collect();
+        if let Some(jq) = &self.jq {
+            argv.push("--jq".to_string());
+            argv.push(jq.clone());
+        }
+        argv
+    }
+}
+
+pub type Response = crate::cli::command::ResponseSchema;
+
+impl TryFrom<Args> for Request {
+    type Error = crate::cli::command::FromArgsError;
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        Ok(Self {
+            path_type: Path::AgentsQueueDeliverResponseSchema,
+            jq: args.jq,
+        })
+    }
+}
+
+#[cfg(feature = "cli-executor")]
+pub async fn execute<E: crate::cli::command::CommandExecutor>(
+    executor: &E,
+    mut request: Request,
+    agent_arguments: Option<&crate::cli::command::AgentArguments>,
+) -> Result<Response, E::Error> {
+    request.jq = None;
+    executor.execute_one(request, agent_arguments).await
+}
+
+#[cfg(feature = "cli-executor")]
+pub async fn execute_jq<E: crate::cli::command::CommandExecutor>(
+    executor: &E,
+    mut request: Request,
+    jq: String,
+    agent_arguments: Option<&crate::cli::command::AgentArguments>,
+) -> Result<serde_json::Value, E::Error> {
+    request.jq = Some(jq);
+    executor.execute_one(request, agent_arguments).await
+}

--- a/objectiveai-sdk-rs/src/cli/command/agents/queue/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/queue/mod.rs
@@ -1,6 +1,10 @@
-//! `agents queue` — deferred prompts queue. Two top-level subcommands:
+//! `agents queue` — deferred prompts queue. Three top-level
+//! subcommands:
 //!
 //! - `delete` — remove one queued prompt by id.
+//! - `deliver` — wake every queue-pending strict descendant of the
+//!   caller (try-lock each AIH; spawn the idle ones with empty
+//!   messages so they drain their own queues).
 //! - `read` (nested) — sub-tier whose only leaf today is `id`,
 //!   which fetches one piece of queued content by its
 //!   `prompt_contents.id`. The wire shape mirrors `RichContentPart`
@@ -15,12 +19,15 @@
 use crate::cli::command::CommandRequest;
 
 pub mod delete;
+pub mod deliver;
 pub mod read;
 
 #[derive(clap::Subcommand)]
 pub enum Command {
     /// Delete one queued prompt by id.
     Delete(delete::Command),
+    /// Wake every queue-pending descendant agent of the caller.
+    Deliver(deliver::Command),
     /// Read queued content — `read id <id>` for a single content
     /// piece, `read pending [parent]` for the list of queued
     /// prompts under a parent.
@@ -48,6 +55,12 @@ pub enum Request {
     DeleteRequestSchema(delete::request_schema::Request),
     #[schemars(title = "DeleteResponseSchema")]
     DeleteResponseSchema(delete::response_schema::Request),
+    #[schemars(title = "Deliver")]
+    Deliver(deliver::Request),
+    #[schemars(title = "DeliverRequestSchema")]
+    DeliverRequestSchema(deliver::request_schema::Request),
+    #[schemars(title = "DeliverResponseSchema")]
+    DeliverResponseSchema(deliver::response_schema::Request),
     #[schemars(title = "Read")]
     Read(read::Request),
 }
@@ -65,6 +78,12 @@ pub enum ResponseItem {
     DeleteRequestSchema(delete::request_schema::Response),
     #[schemars(title = "DeleteResponseSchema")]
     DeleteResponseSchema(delete::response_schema::Response),
+    #[schemars(title = "Deliver")]
+    Deliver(deliver::ResponseItem),
+    #[schemars(title = "DeliverRequestSchema")]
+    DeliverRequestSchema(deliver::request_schema::Response),
+    #[schemars(title = "DeliverResponseSchema")]
+    DeliverResponseSchema(deliver::response_schema::Response),
     #[schemars(title = "Read")]
     Read(read::ResponseItem),
 }
@@ -76,6 +95,9 @@ impl crate::cli::command::CommandResponse for ResponseItem {
             ResponseItem::Delete(v) => v.into_mcp(),
             ResponseItem::DeleteRequestSchema(v) => v.into_mcp(),
             ResponseItem::DeleteResponseSchema(v) => v.into_mcp(),
+            ResponseItem::Deliver(v) => v.into_mcp(),
+            ResponseItem::DeliverRequestSchema(v) => v.into_mcp(),
+            ResponseItem::DeliverResponseSchema(v) => v.into_mcp(),
             ResponseItem::Read(v) => v.into_mcp(),
         }
     }
@@ -94,6 +116,15 @@ impl TryFrom<Command> for Request {
                     Request::DeleteResponseSchema(delete::response_schema::Request::try_from(args)?),
                 ),
             },
+            Command::Deliver(cmd) => match cmd.schema {
+                None => Ok(Request::Deliver(deliver::Request::try_from(cmd.args)?)),
+                Some(deliver::Schema::RequestSchema(args)) => Ok(
+                    Request::DeliverRequestSchema(deliver::request_schema::Request::try_from(args)?),
+                ),
+                Some(deliver::Schema::ResponseSchema(args)) => Ok(
+                    Request::DeliverResponseSchema(deliver::response_schema::Request::try_from(args)?),
+                ),
+            },
             Command::Read(rc) => Ok(Request::Read(read::Request::try_from(rc.sub)?)),
         }
     }
@@ -105,6 +136,9 @@ impl CommandRequest for Request {
             Request::Delete(inner) => inner.into_command(),
             Request::DeleteRequestSchema(inner) => inner.into_command(),
             Request::DeleteResponseSchema(inner) => inner.into_command(),
+            Request::Deliver(inner) => inner.into_command(),
+            Request::DeliverRequestSchema(inner) => inner.into_command(),
+            Request::DeliverResponseSchema(inner) => inner.into_command(),
             Request::Read(inner) => inner.into_command(),
         }
     }
@@ -143,6 +177,24 @@ pub async fn execute<E: crate::cli::command::CommandExecutor>(
                 ResponseItem::DeleteResponseSchema(value),
             )))
         }
+        Request::Deliver(req) => {
+            let inner = deliver::execute(executor, req, agent_arguments).await?;
+            Box::pin(inner.map(|r| r.map(ResponseItem::Deliver)))
+        }
+        Request::DeliverRequestSchema(req) => {
+            let value =
+                deliver::request_schema::execute(executor, req, agent_arguments).await?;
+            Box::pin(crate::cli::command::StreamOnce::new(Ok(
+                ResponseItem::DeliverRequestSchema(value),
+            )))
+        }
+        Request::DeliverResponseSchema(req) => {
+            let value =
+                deliver::response_schema::execute(executor, req, agent_arguments).await?;
+            Box::pin(crate::cli::command::StreamOnce::new(Ok(
+                ResponseItem::DeliverResponseSchema(value),
+            )))
+        }
         Request::Read(req) => {
             let inner = read::execute(executor, req, agent_arguments).await?;
             Box::pin(inner.map(|r| r.map(ResponseItem::Read)))
@@ -176,6 +228,20 @@ pub async fn execute_jq<E: crate::cli::command::CommandExecutor>(
         Request::DeleteResponseSchema(req) => {
             let value =
                 delete::response_schema::execute_jq(executor, req, jq, agent_arguments).await?;
+            Box::pin(crate::cli::command::StreamOnce::new(Ok(value)))
+        }
+        Request::Deliver(req) => {
+            let inner = deliver::execute_jq(executor, req, jq, agent_arguments).await?;
+            Box::pin(inner)
+        }
+        Request::DeliverRequestSchema(req) => {
+            let value =
+                deliver::request_schema::execute_jq(executor, req, jq, agent_arguments).await?;
+            Box::pin(crate::cli::command::StreamOnce::new(Ok(value)))
+        }
+        Request::DeliverResponseSchema(req) => {
+            let value =
+                deliver::response_schema::execute_jq(executor, req, jq, agent_arguments).await?;
             Box::pin(crate::cli::command::StreamOnce::new(Ok(value)))
         }
         Request::Read(req) => {

--- a/objectiveai-sdk-rs/src/cli/command/agents/queue/read/pending/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/agents/queue/read/pending/mod.rs
@@ -17,8 +17,7 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub after_id: Option<i64>,
-    /// Cap on rows scanned per target. Defaults to 1000 server-side
-    /// when omitted.
+    /// Cap on rows scanned per target. `None` = unlimited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub limit: Option<i64>,

--- a/objectiveai-sdk-rs/src/cli/command/tasks/list/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/list/mod.rs
@@ -115,6 +115,17 @@ impl CommandRequest for Request {
     }
 }
 
+/// The plugin that registered a schedule. All three fields are present
+/// together or the whole object is absent (the `schedules` table
+/// enforces all-or-nothing on its `plugin_*` columns).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.tasks.list.Plugin")]
+pub struct Plugin {
+    pub owner: String,
+    pub repository: String,
+    pub version: String,
+}
+
 /// One schedule row.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.list.ResponseItem")]
@@ -141,6 +152,15 @@ pub struct ResponseItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub interval: Option<String>,
+    /// Overwrite count: `1` for a freshly scheduled row, incremented
+    /// each time `tasks schedule --overwrite` replaced it.
+    pub version: u64,
+    /// The plugin that registered this schedule (its `(owner,
+    /// repository, version)` coordinate), or `None` when it was not
+    /// scheduled by a plugin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("omitempty" = true))]
+    pub plugin: Option<Plugin>,
 }
 
 #[derive(clap::Args)]

--- a/objectiveai-sdk-rs/src/cli/command/tasks/list/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/list/mod.rs
@@ -1,39 +1,28 @@
 //! `agents tasks list` — inspection leaf over `schedules`.
 //!
-//! Every filter is optional and additive. Hierarchy scope is
-//! always `parent + descendants` — either `--agent-instance-hierarchy
-//! <h>` (literal), `--tag <name>` (resolves through `tags.sqlite`
-//! BOUND only — errors on PENDING / ABSENT), or, when neither is
-//! given, the cli's own `Config.agent_instance_hierarchy`.
-//! `--depth N` caps the descent depth; `--oneshot` / `--interval`
-//! filter by kind; `--pending` / `--exhausted` filter by
-//! readiness. `--offset` / `--count` paginate.
+//! Scope is one or more `--target` entries (the shared `Target`:
+//! `me` / `instance=L[,parent=P]` / `tag=T`). Each resolves to an AIH
+//! and the listing returns the schedule rows whose
+//! `agent_instance_hierarchy` equals it — exact match, no subtree
+//! descent. `--oneshot` / `--interval` filter by kind; `--pending` /
+//! `--exhausted` filter by readiness; `--after-id` / `--count`
+//! paginate forward by ascending row id.
 
 use crate::cli::command::CommandRequest;
+
+/// The same `Target` every hierarchy-scoped read command uses
+/// (`agents instances list`, `agents logs read all`, …).
+pub use crate::cli::command::agents::logs::read::all::Target;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.list.Request")]
 pub struct Request {
     pub path_type: Path,
-    /// Subtree root for the hierarchy filter. When omitted (and
-    /// `tag` is also `None`), the handler substitutes the cli's
-    /// own `Config.agent_instance_hierarchy`. Mutually exclusive
-    /// with `tag`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("omitempty" = true))]
-    pub agent_instance_hierarchy: Option<String>,
-    /// Tag name; resolved against `tags.sqlite` BOUND-only at
-    /// handler time. PENDING / ABSENT lookups return an error.
-    /// Mutually exclusive with `agent_instance_hierarchy`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("omitempty" = true))]
-    pub tag: Option<String>,
-    /// Maximum descent depth from the hierarchy root. `0` = the
-    /// hierarchy itself only; `1` = direct children; `None` =
-    /// unlimited recursion.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("omitempty" = true))]
-    pub depth: Option<u64>,
+    /// One or more targets to list schedules for. Each resolves to a
+    /// single AIH (`me` → the cli's own; `instance=L[,parent=P]`;
+    /// `tag=T` BOUND-only — PENDING / ABSENT error), and rows whose
+    /// `agent_instance_hierarchy` equals any resolved AIH are returned.
+    pub targets: Vec<Target>,
     /// Filter to oneshot rows only. Mutually exclusive with `interval`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub oneshot: bool,
@@ -51,11 +40,13 @@ pub struct Request {
     /// exclusive with `pending`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub exhausted: bool,
-    /// Row offset for pagination. Defaults to 0.
+    /// Skip rows with `schedules.id <= after_id`. Use the highest
+    /// `id` from a previous page to paginate forward.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
-    pub offset: Option<u64>,
-    /// Row count limit for pagination. `None` = unlimited.
+    pub after_id: Option<i64>,
+    /// Per-target row cap — each target's query returns at most this
+    /// many rows (ascending id, after `after_id`). `None` = unlimited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub count: Option<u64>,
@@ -75,17 +66,9 @@ impl CommandRequest for Request {
             "tasks".to_string(),
             "list".to_string(),
         ];
-        if let Some(h) = &self.agent_instance_hierarchy {
-            argv.push("--agent-instance-hierarchy".to_string());
-            argv.push(h.clone());
-        }
-        if let Some(t) = &self.tag {
-            argv.push("--tag".to_string());
-            argv.push(t.clone());
-        }
-        if let Some(d) = self.depth {
-            argv.push("--depth".to_string());
-            argv.push(d.to_string());
+        for target in &self.targets {
+            argv.push("--target".to_string());
+            argv.push(target.into_arg_string());
         }
         if self.oneshot {
             argv.push("--oneshot".to_string());
@@ -99,9 +82,9 @@ impl CommandRequest for Request {
         if self.exhausted {
             argv.push("--exhausted".to_string());
         }
-        if let Some(o) = self.offset {
-            argv.push("--offset".to_string());
-            argv.push(o.to_string());
+        if let Some(after_id) = self.after_id {
+            argv.push("--after-id".to_string());
+            argv.push(after_id.to_string());
         }
         if let Some(c) = self.count {
             argv.push("--count".to_string());
@@ -130,11 +113,12 @@ pub struct Plugin {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.list.ResponseItem")]
 pub struct ResponseItem {
-    /// Stable identifier — `"{name}-{db_id}"` where `name` is the
-    /// `--name` passed to `agents tasks schedule` and `db_id` is
-    /// the row id from `schedules`. Same shape `agents tasks run`
-    /// tags each emitted item with.
-    pub id: String,
+    /// The `schedules` row id. Monotonic; pass the highest `id` from a
+    /// page as the next request's `after_id` to paginate forward.
+    pub id: i64,
+    /// The `--name` passed to `agents tasks schedule`. Unique per
+    /// `agent_instance_hierarchy`.
+    pub name: String,
     pub agent_instance_hierarchy: String,
     pub command: Vec<String>,
     pub description: String,
@@ -165,11 +149,6 @@ pub struct ResponseItem {
 
 #[derive(clap::Args)]
 #[command(group(
-    clap::ArgGroup::new("scope")
-        .multiple(false)
-        .args(["agent_instance_hierarchy", "tag"])
-))]
-#[command(group(
     clap::ArgGroup::new("kind")
         .multiple(false)
         .args(["oneshot", "interval"])
@@ -180,21 +159,11 @@ pub struct ResponseItem {
         .args(["pending", "exhausted"])
 ))]
 pub struct Args {
-    /// Filter rows to this subtree (inclusive of the parent).
-    /// Mutually exclusive with `--tag`. When neither is given,
-    /// the cli's own `Config.agent_instance_hierarchy` is used.
-    #[arg(long)]
-    pub agent_instance_hierarchy: Option<String>,
-    /// Tag name; resolved against `tags.sqlite` (BOUND-only —
-    /// PENDING / ABSENT raise structured errors). Mutually
-    /// exclusive with `--agent-instance-hierarchy`.
-    #[arg(long)]
-    pub tag: Option<String>,
-    /// Cap the descent depth from the hierarchy root.
-    /// `0` = root only; `1` = root + direct children. Omit for
-    /// unlimited descent.
-    #[arg(long)]
-    pub depth: Option<u64>,
+    /// One or more `--target instance=L[,parent=P]` entries. Also
+    /// accepts `--target tag=T` and `--target me`. Lists schedules
+    /// whose `agent_instance_hierarchy` equals each resolved AIH.
+    #[arg(long = "target", required = true)]
+    pub targets: Vec<String>,
     /// Filter to oneshot rows only. Mutually exclusive with `--interval`.
     #[arg(long)]
     pub oneshot: bool,
@@ -207,8 +176,10 @@ pub struct Args {
     /// Only schedules NOT currently runnable. Mutually exclusive with `--pending`.
     #[arg(long)]
     pub exhausted: bool,
+    /// Skip rows with `schedules.id <= after_id`; use the highest
+    /// `id` from the previous page to paginate forward.
     #[arg(long)]
-    pub offset: Option<u64>,
+    pub after_id: Option<i64>,
     #[arg(long)]
     pub count: Option<u64>,
     #[arg(long)]
@@ -235,16 +206,23 @@ pub enum Schema {
 impl TryFrom<Args> for Request {
     type Error = crate::cli::command::FromArgsError;
     fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let targets = args
+            .targets
+            .iter()
+            .map(|s| {
+                s.parse::<Target>().map_err(|msg| {
+                    crate::cli::command::FromArgsError::path_parse("target", msg)
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             path_type: Path::AgentsTasksList,
-            agent_instance_hierarchy: args.agent_instance_hierarchy,
-            tag: args.tag,
-            depth: args.depth,
+            targets,
             oneshot: args.oneshot,
             interval: args.interval,
             pending: args.pending,
             exhausted: args.exhausted,
-            offset: args.offset,
+            after_id: args.after_id,
             count: args.count,
             jq: args.jq,
         })

--- a/objectiveai-sdk-rs/src/cli/command/tasks/list/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/list/mod.rs
@@ -4,9 +4,12 @@
 //! `me` / `instance=L[,parent=P]` / `tag=T`). Each resolves to an AIH
 //! and the listing returns the schedule rows whose
 //! `agent_instance_hierarchy` equals it — exact match, no subtree
-//! descent. `--oneshot` / `--interval` filter by kind; `--pending` /
-//! `--exhausted` filter by readiness; `--after-id` / `--count`
-//! paginate forward by ascending row id.
+//! descent. Only the NEWEST version of each `(name, aih)` lists;
+//! `--overwrite`-shadowed versions stay on disk (per-version run
+//! history) but never surface here. `--oneshot` / `--interval` filter
+//! by kind; `--pending` / `--exhausted` filter by readiness (derived
+//! from the schedule's newest `tasks_runs` entry); `--after-id` /
+//! `--count` paginate forward by ascending row id.
 
 use crate::cli::command::CommandRequest;
 
@@ -123,8 +126,9 @@ pub struct ResponseItem {
     pub command: Vec<String>,
     pub description: String,
     pub created_at: i64,
-    /// Unix seconds of the most recent invocation. `None` until
-    /// the runner has fired this schedule at least once.
+    /// Unix seconds of the most recent invocation — this row's newest
+    /// `tasks_runs` entry. `None` until the runner has fired this
+    /// version at least once (runs are tracked per-version).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub last_ran_at: Option<i64>,
@@ -136,8 +140,9 @@ pub struct ResponseItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub interval: Option<String>,
-    /// Overwrite count: `1` for a freshly scheduled row, incremented
-    /// each time `tasks schedule --overwrite` replaced it.
+    /// This row's version: `1` for a freshly scheduled task,
+    /// `max + 1` for each `tasks schedule --overwrite` (each version
+    /// is its own row; only the newest lists).
     pub version: u64,
     /// The plugin that registered this schedule (its `(owner,
     /// repository, version)` coordinate), or `None` when it was not

--- a/objectiveai-sdk-rs/src/cli/command/tasks/run/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/run/mod.rs
@@ -61,12 +61,13 @@ impl CommandRequest for Request {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.run.ResponseItem")]
 pub struct ResponseItem {
-    /// The source schedule's `schedules` row id.
-    pub id: i64,
     /// The source schedule's `agent_instance_hierarchy`.
     pub agent_instance_hierarchy: String,
     /// The source schedule's `--name`.
     pub name: String,
+    /// The source schedule's version (`1` on first creation,
+    /// incremented per `schedule --overwrite`).
+    pub version: u64,
     /// The plugin that registered the source schedule, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]

--- a/objectiveai-sdk-rs/src/cli/command/tasks/run/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/run/mod.rs
@@ -1,38 +1,26 @@
-//! `agents tasks run` — fire every pending schedule in scope.
+//! `agents tasks run` — fire every pending schedule in the caller's
+//! own subtree.
 //!
-//! Walks every row that `agents tasks list --pending` would
-//! surface under the given scope, bumps each row's `last_ran_at`
-//! to `now`, deletes oneshots, and dispatches each row's stored
-//! argv through the in-process `CliCommandExecutor` in parallel.
-//! The resulting per-task streams are merged via SelectAll; each
-//! emitted item is wrapped with the source schedule's `name` so
-//! callers can attribute output.
-//!
-//! Only the three scope flags from #216's runner spec —
-//! `--agent-instance-hierarchy` / `--tag` (mutex, neither
-//! required) and `--depth`. Readiness filtering is implicit: the
-//! runner only fires pending rows by definition.
+//! Scope is fixed: every schedule whose `agent_instance_hierarchy` is
+//! the caller's own AIH or a descendant of it. Of those, the runner
+//! fires the pending ones (unfired oneshots + interval rows whose
+//! interval has elapsed), bumps each fired row's `last_ran_at` to
+//! `now`, deletes the oneshots it fired, and dispatches each row's
+//! stored argv through the root `crate::run` in parallel — with the
+//! schedule's captured identity (and the plugin that registered it, if
+//! any) re-installed on the run ctx. The per-task streams are merged;
+//! each emitted item is wrapped with the source schedule's `id`.
 
 use crate::cli::command::CommandRequest;
+
+/// The plugin that registered a schedule — the same shape `tasks list`
+/// surfaces.
+pub use crate::cli::command::tasks::list::Plugin;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.run.Request")]
 pub struct Request {
     pub path_type: Path,
-    /// Literal hierarchy scope. Mutually exclusive with `tag`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("omitempty" = true))]
-    pub agent_instance_hierarchy: Option<String>,
-    /// Tag name; resolved BOUND-only at handler time. PENDING /
-    /// ABSENT raise structured errors. Mutually exclusive with
-    /// `agent_instance_hierarchy`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("omitempty" = true))]
-    pub tag: Option<String>,
-    /// Cap descent depth from the scope root. `None` = unlimited.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("omitempty" = true))]
-    pub depth: Option<u64>,
     pub jq: Option<String>,
 }
 
@@ -49,18 +37,6 @@ impl CommandRequest for Request {
             "tasks".to_string(),
             "run".to_string(),
         ];
-        if let Some(h) = &self.agent_instance_hierarchy {
-            argv.push("--agent-instance-hierarchy".to_string());
-            argv.push(h.clone());
-        }
-        if let Some(t) = &self.tag {
-            argv.push("--tag".to_string());
-            argv.push(t.clone());
-        }
-        if let Some(d) = self.depth {
-            argv.push("--depth".to_string());
-            argv.push(d.to_string());
-        }
         if let Some(jq) = &self.jq {
             argv.push("--jq".to_string());
             argv.push(jq.clone());
@@ -69,15 +45,12 @@ impl CommandRequest for Request {
     }
 }
 
-/// One output item from one fired schedule's in-process stream.
-/// `id` is the source schedule's stable identifier, formatted
-/// `"{name}-{db_id}"` so it's both human-readable (the user-
-/// supplied `--name` from `schedule`) and globally unique (the
-/// row id from `schedules`). `value` is the typed root
-/// [`crate::cli::command::ResponseItem`] emitted by the scheduled
-/// cli leaf — boxed because the root union transitively contains
-/// *this* variant (`agents → tasks → run`), and boxing is what
-/// makes the recursion sized.
+/// One output item from one fired schedule's in-process stream. The
+/// first four fields identify the source schedule; `value` is the
+/// typed root [`crate::cli::command::ResponseItem`] emitted by the
+/// scheduled cli leaf — boxed because the root union transitively
+/// contains *this* variant (`agents → tasks → run`), and boxing is
+/// what makes the recursion sized.
 ///
 /// The `value` field's JSON schema is opaqued to `serde_json::Value`
 /// (renders as bare `{}` aka JsonValue) so the published schema
@@ -88,31 +61,23 @@ impl CommandRequest for Request {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.run.ResponseItem")]
 pub struct ResponseItem {
-    pub id: String,
+    /// The source schedule's `schedules` row id.
+    pub id: i64,
+    /// The source schedule's `agent_instance_hierarchy`.
+    pub agent_instance_hierarchy: String,
+    /// The source schedule's `--name`.
+    pub name: String,
+    /// The plugin that registered the source schedule, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("omitempty" = true))]
+    pub plugin: Option<Plugin>,
+    /// The typed root item emitted by the scheduled command.
     #[schemars(with = "serde_json::Value")]
     pub value: Box<crate::cli::command::ResponseItem>,
 }
 
 #[derive(clap::Args)]
-#[command(group(
-    clap::ArgGroup::new("scope")
-        .multiple(false)
-        .args(["agent_instance_hierarchy", "tag"])
-))]
 pub struct Args {
-    /// Subtree root for the hierarchy filter. Mutually exclusive
-    /// with `--tag`. When neither is set, the cli's own
-    /// `Config.agent_instance_hierarchy` is used.
-    #[arg(long)]
-    pub agent_instance_hierarchy: Option<String>,
-    /// Tag name; resolved against `tags.sqlite` BOUND-only.
-    /// Mutually exclusive with `--agent-instance-hierarchy`.
-    #[arg(long)]
-    pub tag: Option<String>,
-    /// Cap the descent depth from the scope root. Omit for
-    /// unlimited descent.
-    #[arg(long)]
-    pub depth: Option<u64>,
     #[arg(long)]
     pub jq: Option<String>,
 }
@@ -139,9 +104,6 @@ impl TryFrom<Args> for Request {
     fn try_from(args: Args) -> Result<Self, Self::Error> {
         Ok(Self {
             path_type: Path::AgentsTasksRun,
-            agent_instance_hierarchy: args.agent_instance_hierarchy,
-            tag: args.tag,
-            depth: args.depth,
             jq: args.jq,
         })
     }

--- a/objectiveai-sdk-rs/src/cli/command/tasks/run/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/run/mod.rs
@@ -3,13 +3,22 @@
 //!
 //! Scope is fixed: every schedule whose `agent_instance_hierarchy` is
 //! the caller's own AIH or a descendant of it. Of those, the runner
-//! fires the pending ones (unfired oneshots + interval rows whose
-//! interval has elapsed), bumps each fired row's `last_ran_at` to
-//! `now`, deletes the oneshots it fired, and dispatches each row's
-//! stored argv through the root `crate::run` in parallel — with the
-//! schedule's captured identity (and the plugin that registered it, if
-//! any) re-installed on the run ctx. The per-task streams are merged;
-//! each emitted item is wrapped with the source schedule's `id`.
+//! claims the pending ones (unfired oneshots + interval rows whose
+//! interval has elapsed — newest versions only), minting one
+//! `tasks_runs` row per firing, and dispatches each row's stored argv
+//! through the root `crate::run` in parallel — with the schedule's
+//! captured identity (and the plugin that registered it, if any)
+//! re-installed on the run ctx.
+//!
+//! Two output modes, selected by `stream_all`:
+//! * `--stream-all`: every item every task emits streams back, each
+//!   wrapped as a [`ValueResponseItem`].
+//! * default: exactly ONE [`SuccessResponseItem`] per task, emitted
+//!   when that task's stream completes — `success` is `false` iff the
+//!   task's final item was an error.
+//!
+//! The mode affects only the caller-visible stream: in BOTH modes the
+//! full per-item output is durably written to `tasks_logs`.
 
 use crate::cli::command::CommandRequest;
 
@@ -21,6 +30,12 @@ pub use crate::cli::command::tasks::list::Plugin;
 #[schemars(rename = "cli.command.tasks.run.Request")]
 pub struct Request {
     pub path_type: Path,
+    /// Stream every item every fired task emits (each a
+    /// [`ValueResponseItem`]). When false — the default — each task
+    /// yields exactly one [`SuccessResponseItem`] summary instead; the
+    /// full output still lands in `tasks_logs` either way.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stream_all: bool,
     pub jq: Option<String>,
 }
 
@@ -37,6 +52,9 @@ impl CommandRequest for Request {
             "tasks".to_string(),
             "run".to_string(),
         ];
+        if self.stream_all {
+            argv.push("--stream-all".to_string());
+        }
         if let Some(jq) = &self.jq {
             argv.push("--jq".to_string());
             argv.push(jq.clone());
@@ -45,12 +63,27 @@ impl CommandRequest for Request {
     }
 }
 
-/// One output item from one fired schedule's in-process stream. The
-/// first four fields identify the source schedule; `value` is the
-/// typed root [`crate::cli::command::ResponseItem`] emitted by the
-/// scheduled cli leaf — boxed because the root union transitively
-/// contains *this* variant (`agents → tasks → run`), and boxing is
-/// what makes the recursion sized.
+/// One stream item from `tasks run`. Untagged — the variants'
+/// required fields (`value` vs `success`) are disjoint, so the wire
+/// shape is just the inner object. Which variant flows is decided by
+/// the request's `stream_all`: `true` streams every emitted item as a
+/// [`ValueResponseItem`]; `false` (default) yields exactly one
+/// [`SuccessResponseItem`] per task when its stream completes.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+#[schemars(rename = "cli.command.tasks.run.ResponseItem")]
+pub enum ResponseItem {
+    Value(ValueResponseItem),
+    Success(SuccessResponseItem),
+}
+
+/// One output item from one fired schedule's in-process stream
+/// (`stream_all` mode). The first four fields identify the source
+/// schedule; `value` is the typed root
+/// [`crate::cli::command::ResponseItem`] emitted by the scheduled cli
+/// leaf — boxed because the root union transitively contains *this*
+/// type (`agents → tasks → run`), and boxing is what makes the
+/// recursion sized.
 ///
 /// The `value` field's JSON schema is opaqued to `serde_json::Value`
 /// (renders as bare `{}` aka JsonValue) so the published schema
@@ -59,8 +92,8 @@ impl CommandRequest for Request {
 /// Downstream SDKs see `value: JsonValue` on the typed `execute`
 /// path; consumers that want to peer inside parse it case-by-case.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-#[schemars(rename = "cli.command.tasks.run.ResponseItem")]
-pub struct ResponseItem {
+#[schemars(rename = "cli.command.tasks.run.ValueResponseItem")]
+pub struct ValueResponseItem {
     /// The source schedule's `agent_instance_hierarchy`.
     pub agent_instance_hierarchy: String,
     /// The source schedule's `--name`.
@@ -77,8 +110,36 @@ pub struct ResponseItem {
     pub value: Box<crate::cli::command::ResponseItem>,
 }
 
+/// One per-task completion summary (default mode): the same schedule
+/// identity as [`ValueResponseItem`], with `success` in lieu of
+/// `value`. `success` is `false` iff the task's FINAL emitted item was
+/// an error (a task that emitted nothing is a success). The task's
+/// full output is in `tasks_logs` regardless.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "cli.command.tasks.run.SuccessResponseItem")]
+pub struct SuccessResponseItem {
+    /// The source schedule's `agent_instance_hierarchy`.
+    pub agent_instance_hierarchy: String,
+    /// The source schedule's `--name`.
+    pub name: String,
+    /// The source schedule's version (`1` on first creation,
+    /// incremented per `schedule --overwrite`).
+    pub version: u64,
+    /// The plugin that registered the source schedule, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("omitempty" = true))]
+    pub plugin: Option<Plugin>,
+    /// Whether the task's stream completed without a trailing error.
+    pub success: bool,
+}
+
 #[derive(clap::Args)]
 pub struct Args {
+    /// Stream every item every fired task emits. Without this flag
+    /// each task yields exactly one `{.., success}` summary when it
+    /// completes; the full output lands in `tasks_logs` either way.
+    #[arg(long)]
+    pub stream_all: bool,
     #[arg(long)]
     pub jq: Option<String>,
 }
@@ -105,6 +166,7 @@ impl TryFrom<Args> for Request {
     fn try_from(args: Args) -> Result<Self, Self::Error> {
         Ok(Self {
             path_type: Path::AgentsTasksRun,
+            stream_all: args.stream_all,
             jq: args.jq,
         })
     }

--- a/objectiveai-sdk-rs/src/cli/command/tasks/schedule/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/schedule/mod.rs
@@ -19,11 +19,11 @@ use crate::cli::command::CommandRequest;
 #[schemars(rename = "cli.command.tasks.schedule.Request")]
 pub struct Request {
     pub path_type: Path,
-    /// User-facing identifier. Globally unique — a second
-    /// `schedule` with the same name fails the
-    /// `schedules.name` UNIQUE constraint. `agents tasks run`
-    /// tags every streamed output line with this name so the
-    /// caller can attribute output to its source schedule.
+    /// User-facing identifier. Unique per agent instance hierarchy —
+    /// a second `schedule` with the same `(name, aih)` fails the
+    /// `schedules` UNIQUE constraint unless `overwrite` is set.
+    /// `agents tasks run` tags every streamed output line with this
+    /// name so the caller can attribute output to its source schedule.
     pub name: String,
     /// argv to invoke on each scheduled poll.
     pub command: Vec<String>,
@@ -39,6 +39,11 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub interval_seconds: Option<u64>,
+    /// Replace an existing `(name, agent_instance_hierarchy)` row
+    /// instead of erroring on collision. Each overwrite bumps the
+    /// row's `version` (starts at 1) and resets its run state.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub overwrite: bool,
     pub jq: Option<String>,
 }
 
@@ -71,6 +76,9 @@ impl CommandRequest for Request {
                 );
             }
             None => argv.push("--oneshot".to_string()),
+        }
+        if self.overwrite {
+            argv.push("--overwrite".to_string());
         }
         if let Some(jq) = &self.jq {
             argv.push("--jq".to_string());
@@ -120,6 +128,11 @@ pub struct Args {
     /// delete the row. Mutually exclusive with `--interval`.
     #[arg(long)]
     pub oneshot: bool,
+    /// Replace an existing `(name, agent-instance-hierarchy)`
+    /// schedule instead of erroring on collision. Bumps the row's
+    /// `version` (starting at 1) and resets its run state.
+    #[arg(long)]
+    pub overwrite: bool,
     /// jq filter applied to the JSON output.
     #[arg(long)]
     pub jq: Option<String>,
@@ -183,6 +196,7 @@ impl TryFrom<Args> for Request {
             command: args.command,
             description: args.description,
             interval_seconds,
+            overwrite: args.overwrite,
             jq: args.jq,
         })
     }

--- a/objectiveai-sdk-rs/src/cli/command/tasks/schedule/mod.rs
+++ b/objectiveai-sdk-rs/src/cli/command/tasks/schedule/mod.rs
@@ -39,9 +39,11 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("omitempty" = true))]
     pub interval_seconds: Option<u64>,
-    /// Replace an existing `(name, agent_instance_hierarchy)` row
-    /// instead of erroring on collision. Each overwrite bumps the
-    /// row's `version` (starts at 1) and resets its run state.
+    /// Shadow an existing `(name, agent_instance_hierarchy)` schedule
+    /// instead of erroring on collision: a NEW row is inserted with
+    /// `version = max + 1`. Older versions never list or run again but
+    /// are kept so run history stays per-version; the new version has
+    /// no runs yet, so it fires fresh.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub overwrite: bool,
     pub jq: Option<String>,
@@ -92,14 +94,17 @@ impl CommandRequest for Request {
     }
 }
 
-/// `id` is the stable identifier `"{name}-{db_id}"` — the
-/// user-supplied `--name` joined to the row id from
-/// `tasks.sqlite`'s `schedules` table. Same shape `list` and
-/// `run` use to identify rows on the wire.
+/// The created schedule's user-facing identity: its `--name`, the
+/// caller hierarchy it was registered under, and the version this call
+/// minted (`1` on first creation, `max + 1` per `--overwrite` — each
+/// version is its own row; older versions are shadowed but kept for
+/// per-version run history).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[schemars(rename = "cli.command.tasks.schedule.Response")]
 pub struct Response {
-    pub id: String,
+    pub name: String,
+    pub agent_instance_hierarchy: String,
+    pub version: u64,
 }
 
 #[derive(clap::Args)]
@@ -128,9 +133,10 @@ pub struct Args {
     /// delete the row. Mutually exclusive with `--interval`.
     #[arg(long)]
     pub oneshot: bool,
-    /// Replace an existing `(name, agent-instance-hierarchy)`
-    /// schedule instead of erroring on collision. Bumps the row's
-    /// `version` (starting at 1) and resets its run state.
+    /// Shadow an existing `(name, agent-instance-hierarchy)` schedule
+    /// instead of erroring on collision: inserts a NEW version
+    /// (`max + 1`) that supersedes the old ones. Old versions keep
+    /// their run history but never list or run again.
     #[arg(long)]
     pub overwrite: bool,
     /// jq filter applied to the JSON output.


### PR DESCRIPTION
## Overview

Reworks the entire `tasks` subsystem (schedule / list / run) around durable, versioned, per-agent state, and adds three more things on top: in-process plugin nested commands, `agents queue deliver`, and MCP alignment with the new plugin/tool run surface.

## `tasks schedule`
- **Names are unique per `(name, agent_instance_hierarchy)`** — different agents can reuse a name.
- **Versions are rows.** `--overwrite` no longer updates in place: it inserts a NEW row with `version = max+1` that *shadows* the older versions (they never list or run again, but stay on disk so run history is per-version). Without `--overwrite`, a collision errors (`ScheduleAlreadyExists`).
- **Plugin attribution.** If a plugin registers a schedule, its `(owner, repository, version)` triple is captured on the row (all-or-nothing CHECK) from `ctx.plugin`.
- Response is now `{name, agent_instance_hierarchy, version}` (the `"{name}-{db_id}"` join is gone).

## `tasks list`
- Rebuilt on the shared **`Target` pattern** (`--target me | instance=L[,parent=P] | tag=T`, repeatable) — same surface as `agents instances list` / `agents logs read` / `agents queue read`. Drops `--agent-instance-hierarchy` / `--tag` / `--depth`; exact-AIH match, no subtree descent.
- **Keyset pagination** via `--after-id` (replaces `--offset`); ResponseItem carries a numeric `id` + separate `name` so the cursor works.
- Shows only each schedule's **newest version**; `last_ran_at` is derived from the newest run.
- Per-target **concurrent streaming**: every target resolves + queries in parallel, items yield as each lands (also applied to `agents instances list`), deduped via seen-set. Per-target `count`/`limit` now defaults to **unlimited** across the logs/queue/tasks readers (the 1000-row default is gone).

## `tasks run`
- **Fixed scope**: always the caller's own AIH + all descendants — no scope params.
- **Tasks are never deleted.** `last_ran_at` is replaced by a `tasks_runs` table (one row per firing). A oneshot is exhausted the moment it has a run; recurring readiness keys off the newest run.
- **Race-free claim**: the claim transaction takes `pg_advisory_xact_lock`, then ONE CTE statement both selects the eligible schedules and inserts their `tasks_runs` rows — two concurrent `tasks run` calls can never double-fire (eligibility reads a different table than the claim writes, so row locks alone can't prevent it).
- **Per-run output logs**: a spawned log-writer listener drains an unbounded channel into the new `tasks_logs` table (one row per emitted item, keyed by `run_id`); the stream wrapper drops the sender and awaits the writer so every line is durably written before the stream ends. Logging is identical in both output modes.
- **Dispatch via the root `crate::run`** — the same entry `main.rs` uses — with the schedule's captured identity AND its registering plugin re-installed on the per-task ctx (`config.plugin_*` + `ctx.plugin`).
- **Two output modes** (`--stream-all`): the default yields exactly one `{aih, name, version, plugin?, success}` summary per task as it completes (`success=false` iff its final item was an error); `--stream-all` streams every item as `{aih, name, version, plugin?, value}`. Untagged `Value`/`Success` enum.

## Plugins: in-process nested commands
- A plugin-issued command no longer re-execs a whole `objectiveai-cli` subprocess (and re-bootstraps Postgres) per command — it runs **in-process** through the same `crate::run` entry, mirroring `main.rs::run_command` line-for-line, forwarding each output line into the plugin's stdin wrapped in `PluginCommandResponse`.
- Plugins may **not** invoke `plugins` or `tools` commands (`PluginCommandForbidden`).
- The nested ctx carries the plugin coordinate on both `ctx.plugin` and `config.plugin_*`.

## `agents queue deliver` (new)
- Wakes every **queue-pending strict descendant** of the caller (targets from `list_delivery_targets`, caller excluded). Per AIH: try-acquire the agent's lock file with no waiting — a live owner yields `AgentActive{aih}`; winning yields `AgentSpawned{aih}` and runs the same spawn machinery `agents spawn`/`agents message` use (empty messages + stored continuation), streaming spawn output as `Value{aih, value}` envelopes. **Lock ownership transfers into the per-AIH stream** and releases the moment that task's stream ends.
- Once every target resolves, the bare string `"AllAgentsActive"` is emitted.
- Default mode re-execs the cli as a **detached orphan** (`dangerous_advanced.stream_spawns=true` on the child), yields only the status items up to and including `AllAgentsActive`, and returns while the orphan finishes the spawns; `stream_spawns=true` runs the full delivery in-process.

## MCP
- Verified `objectiveai-mcp` builds the plugin/tool dispatch through the SDK `plugins::run::Request` / `tools::run::Request` structs with the discovered `(owner, name, version)` + caller `args`; refreshed the stale input-schema descriptions.

## Schema (inline `CREATE TABLE IF NOT EXISTS` only — fresh DBs, no migrations)
- `schedules`: `UNIQUE (name, agent_instance_hierarchy, version)`, plugin triple columns + CHECK, `version` column; `last_ran_at` dropped.
- New `tasks_runs` (schedule_id FK, ran_at) and `tasks_logs` (run_id FK, value, created_at) with indexes.

## Deferred (follow-ups)
- JSON-schema regen + JS/Go/Py/.NET bindings for the changed wire shapes.

## Verification
- `cargo check` green throughout for `objectiveai-sdk` (incl. `--all-features`), `objectiveai-cli` (lib + test build), and `objectiveai-mcp`; filesystem unit tests pass. CLI integration tests intentionally not run in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)