### PR TITLE
Remove unnecessary package.json copy in Dockerfile

### DIFF
--- a/objectiveai-web/Dockerfile
+++ b/objectiveai-web/Dockerfile
@@ -42,7 +42,6 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /root
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
 COPY objectiveai-sdk-js/package.json objectiveai-sdk-js/
-COPY objectiveai-viewer-sdk/package.json objectiveai-viewer-sdk/
 COPY objectiveai-web/package.json objectiveai-web/
 COPY objectiveai-viewer/package.json objectiveai-viewer/
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixes the objective-ai-web-main Cloud Build, which has failed on every push since May 14 (live site is stuck on revision 00031).

Problem: docker build fails with `COPY objectiveai-viewer-sdk/package.json ... : file not found in build context`.

Cause: objectiveai-viewer-sdk was absorbed into objectiveai-sdk-js (./viewer subpath export) on May 14, removing the standalone folder. objectiveai-web/Dockerfile still referenced it.

Fix: remove the stale `COPY objectiveai-viewer-sdk/package.json objectiveai-viewer-sdk/` line. It was the only remaining reference in the build; lockfiles + pnpm-workspace.yaml were already updated, and the viewer code still ships inside objectiveai-sdk-js.

Heads-up: merging deploys ~6 weeks of accumulated main changes, not just the recent tagline edit.