### PR TITLE
Change 'agent' to 'agent_full_id' in useExecution.ts

### DIFF
--- a/objectiveai-web/lib/useExecution.ts
+++ b/objectiveai-web/lib/useExecution.ts
@@ -122,10 +122,10 @@ function extractDisplayData(chunk: Chunk | null): {
 
   for (const task of chunk.tasks) {
     if (!("votes" in task) || !("scores" in task) || !("weights" in task)) continue;
-    const vcTask = task as { votes: Array<{ agent: string; vote: number[]; weight: number }>; scores: number[]; weights: number[] };
+    const vcTask = task as { votes: Array<{ agent_full_id: string; vote: number[]; weight: number }>; scores: number[]; weights: number[] };
     if (!Array.isArray(vcTask.votes) || !Array.isArray(vcTask.scores) || !Array.isArray(vcTask.weights)) continue;
     const votes: DisplayVote[] = vcTask.votes.map((v) => ({
-      agent: v.agent,
+      agent: v.agent_full_id,
       vote: v.vote,
       weight: v.weight,
     }));
@@ -146,7 +146,7 @@ function toJudgmentExecution(chunk: Chunk | null): JudgmentExecution | null {
     tasks: chunk.tasks.map((task, i) => {
       if ("votes" in task && "scores" in task) {
         const vcTask = task as {
-          votes: Array<{ agent: string; vote: number[]; weight: number; from_cache?: boolean; from_rng?: boolean }>;
+          votes: Array<{ agent_full_id: string; vote: number[]; weight: number; from_cache?: boolean; from_rng?: boolean }>;
           scores: number[];
           completions?: Array<Record<string, unknown>>;
         };
@@ -154,7 +154,7 @@ function toJudgmentExecution(chunk: Chunk | null): JudgmentExecution | null {
         return {
           task_path: [i],
           votes: vcTask.votes.map((v) => ({
-            model: v.agent,
+            model: v.agent_full_id,
             vote: v.vote,
             weight: v.weight,
             from_cache: v.from_cache,


### PR DESCRIPTION
Round-two fix for the web deploy. After the Dockerfile fix (#241), the build reached the Next.js TypeScript check and failed: useExecution.ts read `v.agent` on the vote objects, but post-SDK-refactor that field is now `agent_full_id`.

Updates both casts + reads (extractDisplayData -> DisplayVote.agent, and toJudgmentExecution -> model) to source from `agent_full_id`, per Ronald. Output field names (agent / model) are unchanged.

Merging this should complete the deploy and ship the swarm-harness site.