### PR TITLE
web(deploy): point auth + API at objectiveai.dev (Phase 1)

### DIFF
--- a/objectiveai-web/cloudbuild.yaml
+++ b/objectiveai-web/cloudbuild.yaml
@@ -27,11 +27,11 @@ steps:
       - "--build-arg"
       - "AUTH_REDDIT_CLIENT_SECRET=$_AUTH_REDDIT_CLIENT_SECRET"
       - "--build-arg"
-      - "NEXTAUTH_URL=$_NEXTAUTH_URL"
+      - "NEXTAUTH_URL=https://objectiveai.dev"
       - "--build-arg"
       - "NEXTAUTH_SECRET=$_NEXTAUTH_SECRET"
       - "--build-arg"
-      - "NEXT_PUBLIC_API_URL=$_NEXT_PUBLIC_API_URL"
+      - "NEXT_PUBLIC_API_URL=https://api.objectiveai.dev"
       - "--build-arg"
       - "NODE_ENV=$_NODE_ENV"
       - "--build-arg"
@@ -70,3 +70,6 @@ images: ["us-docker.pkg.dev/$PROJECT_ID/objectiveai/objectiveai-web:latest"]
 timeout: "2100s"
 options:
   logging: "CLOUD_LOGGING_ONLY"
+  # the two domains above are now hardcoded; tolerate the now-unused
+  # _NEXTAUTH_URL / _NEXT_PUBLIC_API_URL trigger substitutions
+  substitution_option: "ALLOW_LOOSE"


### PR DESCRIPTION
**Phase 1 of the deploy hardening — domain fix only (low risk, no infra deps).**

The `objective-ai-web-main` Cloud Build trigger had:
- `NEXTAUTH_URL=https://objective-ai.io`
- `NEXT_PUBLIC_API_URL=https://api.objective-ai.io`

`objective-ai.io` is **not ours** (foreign Cloudflare site; appears nowhere in the repo). Every SDK + the README use `objectiveai.dev` / `api.objectiveai.dev`. This hardcodes the correct domains in `cloudbuild.yaml`.

`substitution_option: ALLOW_LOOSE` lets the build ignore the now-unused `_NEXTAUTH_URL` / `_NEXT_PUBLIC_API_URL` trigger substitutions (cleaned up in Phase 2).

**Safe to merge now:** site is pre-launch (marketing page, no auth/API in use). `api.objectiveai.dev` still needs DNS + a backend, but that's no worse than today (the old domain didn't resolve either).

**Phase 2 (separate):** move the auth secrets out of `--build-arg` into Secret Manager / Cloud Run runtime env (needs Secret Manager setup first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)