### PR TITLE
build(js): fix workspace filter so the JS SDK actually builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.25.0",
   "scripts": {
     "dev": "pnpm --filter objectiveai-web run dev",
-    "build:js": "pnpm --filter objectiveai-sdk run build",
+    "build:js": "pnpm --filter @objectiveai/sdk run build",
     "build:web": "pnpm --filter objectiveai-web run build",
     "build": "pnpm run build:js && pnpm run build:web"
   },


### PR DESCRIPTION
Root `build:js` ran `pnpm --filter objectiveai-sdk run build`, but the package is named **`@objectiveai/sdk`** (dir `objectiveai-sdk-js`). The filter matched nothing — `"No projects matched the filters in /root"` — so the SDK build silently no-op'd on every CI run. It only worked because the SDK's `dist/` is committed.

**Fix:** filter on `@objectiveai/sdk`.

**Verified locally:**
- `pnpm run build:js` now actually builds the SDK (tsup CJS/ESM/DTS ✓).
- `install-wasm.cjs` skips cleanly when no wasm dist is present ("WASM loader already present, skipping") — so no Rust/wasm toolchain is needed in the Docker build.
- The regenerated `dist/` is **byte-identical** to the committed one → nothing about what ships changes. CI just rebuilds the SDK instead of skipping it, which catches future SDK source drift (the kind that caused the recent web breakages).

One-line change. Safe to merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)